### PR TITLE
공통 응답 및 예외 처리 핸들러 추가, 스웨거 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,20 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.zipline'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -28,7 +28,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'com.amazonaws:aws-java-sdk-secretsmanager:1.12.429'
     implementation 'com.bucket4j:bucket4j-core:8.10.1'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -38,10 +38,10 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // 도커 이미지를 빌드하기 위한 bootBuildImage 설정
 tasks.named('bootJar') {
-	archiveFileName = 'app.jar'
+    archiveFileName = 'app.jar'
 }

--- a/src/main/java/com/zipline/global/common/response/ApiResponse.java
+++ b/src/main/java/com/zipline/global/common/response/ApiResponse.java
@@ -1,0 +1,47 @@
+package com.zipline.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+	private boolean success;
+	private int code;
+	private String message;
+	private T data;
+
+	private ApiResponse(boolean success, int code, String message, T data) {
+		this.success = success;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+		return new ApiResponse<>(true, status.value(), message, data);
+	}
+
+	public static <T> ApiResponse<T> success(HttpStatus status, String message) {
+		return new ApiResponse<>(true, status.value(), message, null);
+	}
+
+	public static <T> ApiResponse<T> ok(String message, T data) {
+		return new ApiResponse<>(true, 200, message, data);
+	}
+
+	public static <T> ApiResponse<T> ok(String message) {
+		return new ApiResponse<>(true, 200, message, null);
+	}
+
+	public static <T> ApiResponse<T> create(String message, T data) {
+		return new ApiResponse<>(true, 201, message, data);
+	}
+
+	public static <T> ApiResponse<T> create(String message) {
+		return new ApiResponse<>(true, 201, message, null);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/ExceptionResponseDTO.java
+++ b/src/main/java/com/zipline/global/exception/ExceptionResponseDTO.java
@@ -1,0 +1,20 @@
+package com.zipline.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponseDTO {
+	private int code;
+	private String message;
+
+	private ExceptionResponseDTO(int code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+
+	public static ExceptionResponseDTO of(HttpStatus httpStatus, String message) {
+		return new ExceptionResponseDTO(httpStatus.value(), message);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.zipline.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.zipline.global.exception.custom.BaseException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<ExceptionResponseDTO> handleException(BaseException e) {
+		log.error(e.getMessage(), e);
+		ExceptionResponseDTO response = ExceptionResponseDTO.of(e.getStatus(), e.getMessage());
+		return ResponseEntity.status(e.getStatus()).body(response);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ExceptionResponseDTO> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+		ExceptionResponseDTO response = ExceptionResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR,
+			"서버 에러가 발생하였습니다.");
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/custom/BaseException.java
+++ b/src/main/java/com/zipline/global/exception/custom/BaseException.java
@@ -1,0 +1,15 @@
+package com.zipline.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+	private HttpStatus status;
+
+	public BaseException(String message, HttpStatus status) {
+		super(message);
+		this.status = status;
+	}
+}


### PR DESCRIPTION
## 📝작업 내용
> Swagger 2.0.2 Version - RestControllerAdvice 생성 시 `Handler dispatch failed: java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)` 오류 발생 -> Swagger 2.7.0 Version으로 변경

>공통 응답 Class 생성
 - Success시 ApiResponse
 - Exception시 ExceptionResponseDTO

> GlobalExceptionHandler 생성
> BaseException 생성
 - RuntimeException을 extends하며, HttpStatus 필드를 가짐
