### PR TITLE
fix: findById() 중복 사용 문제

### DIFF
--- a/src/main/java/com/zipline/repository/UserRepository.java
+++ b/src/main/java/com/zipline/repository/UserRepository.java
@@ -4,10 +4,9 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.zipline.entity.User;
-
-import io.lettuce.core.dynamic.annotation.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT user FROM User user WHERE user.id = :id")

--- a/src/main/java/com/zipline/repository/UserRepository.java
+++ b/src/main/java/com/zipline/repository/UserRepository.java
@@ -3,11 +3,13 @@ package com.zipline.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.zipline.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findById(String id);
+	@Query("SELECT user FROM User user WHERE user.id = :id")
+	Optional<User> findByLoginId(String id);
 
 	boolean existsById(String id);
 }

--- a/src/main/java/com/zipline/repository/UserRepository.java
+++ b/src/main/java/com/zipline/repository/UserRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.zipline.entity.User;
 
+import io.lettuce.core.dynamic.annotation.Param;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT user FROM User user WHERE user.id = :id")
-	Optional<User> findByLoginId(String id);
+	Optional<User> findByLoginId(@Param("id") String id);
 
 	boolean existsById(String id);
 }

--- a/src/main/java/com/zipline/service/CustomUserDetailService.java
+++ b/src/main/java/com/zipline/service/CustomUserDetailService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
 	@Override
 	@Transactional
 	public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-		return userRepository.findById(id)
+		return userRepository.findByLoginId(id)
 			.map(this::createUserDetails)
 			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 	}

--- a/src/main/java/com/zipline/service/UserService.java
+++ b/src/main/java/com/zipline/service/UserService.java
@@ -74,7 +74,7 @@ public class UserService {
 		}
 
 		//1. 사용자 조회
-		User user = userRepository.findById(userRequestDto.getId())
+		User user = userRepository.findByLoginId(userRequestDto.getId())
 			.orElseThrow(() -> new UserNotFoundException("아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST));
 
 		// 2. 비밀번호 검증


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 

## 📝작업 내용
> findById()는 uid 조회에만 사용하고 id 비교를 위한 메서드는 findByLoginId()로 분리해 사용
