### PR TITLE
feat: Customer 수정

### DIFF
--- a/src/main/java/com/zipline/controller/CustomerController.java
+++ b/src/main/java/com/zipline/controller/CustomerController.java
@@ -4,11 +4,15 @@ import java.security.Principal;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zipline.dto.CustomerModifyRequestDTO;
+import com.zipline.dto.CustomerModifyResponseDTO;
 import com.zipline.dto.CustomerRegisterRequestDTO;
 import com.zipline.global.common.response.ApiResponse;
 import com.zipline.service.CustomerService;
@@ -27,10 +31,19 @@ public class CustomerController {
 
 	@PostMapping("/customers")
 	public ResponseEntity<ApiResponse<Void>> registerCustomer(
-		@Valid @RequestBody CustomerRegisterRequestDTO customerRegisterRequestDTO,
-		Principal principal) {
+		@Valid @RequestBody CustomerRegisterRequestDTO customerRegisterRequestDTO, Principal principal) {
+
 		ApiResponse<Void> response = customerService.registerCustomer(customerRegisterRequestDTO,
 			Long.parseLong(principal.getName()));
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@PutMapping("/customers/{customerUid}")
+	public ResponseEntity<ApiResponse<CustomerModifyResponseDTO>> modifyCustomer(@PathVariable Long customerUid,
+		@Valid @RequestBody CustomerModifyRequestDTO customerModifyRequestDTO, Principal principal) {
+
+		ApiResponse<CustomerModifyResponseDTO> response = customerService.modifyCustomer(
+			customerUid, customerModifyRequestDTO, Long.parseLong(principal.getName()));
+		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 }

--- a/src/main/java/com/zipline/dto/CustomerModifyRequestDTO.java
+++ b/src/main/java/com/zipline/dto/CustomerModifyRequestDTO.java
@@ -1,0 +1,72 @@
+package com.zipline.dto;
+
+import java.math.BigInteger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomerModifyRequestDTO {
+	@Schema(description = "사용자 이름", example = "홍길동", required = true)
+	@NotBlank(message = "이름은 필수 입력 항목입니다.")
+	private String name;
+
+	@Schema(description = "전화번호", example = "010-1234-5678", required = true)
+	@Pattern(regexp = "^(\\d{3})-(\\d{3,4})-(\\d{4})$", message = "전화번호 형식이 올바르지 않습니다.")
+	private String phoneNo;
+
+	@Schema(description = "주소", example = "서울특별시 강남구 테헤란로")
+	@NotBlank(message = "주소는 필수 입력 항목입니다.")
+	private String address;
+
+	@Schema(description = "통신사", example = "SKT")
+	private String telProvider;
+
+	@Schema(description = "지역", example = "강남")
+	private String region;
+
+	@Schema(description = "최소 임대료", example = "100000")
+	@DecimalMin(value = "0", message = "최소 임대료는 0 이상이어야 합니다.")
+	private BigInteger minRent;
+
+	@Schema(description = "최대 임대료", example = "500000")
+	@DecimalMax(value = "100000000000", message = "최대 임대료는 100000000000 이하여야 합니다.")
+	private BigInteger maxRent;
+
+	@Schema(description = "유입 경로", example = "직방")
+	private String trafficSource;
+
+	@Schema(description = "임대인 여부", example = "true")
+	private boolean isLandlord;
+
+	@Schema(description = "임차인 여부", example = "true")
+	private boolean isTenant;
+
+	@Schema(description = "매수인 여부", example = "false")
+	private boolean isBuyer;
+
+	@Schema(description = "매도인 여부", example = "false")
+	private boolean isSeller;
+
+	@Schema(description = "최대 가격", example = "100000000")
+	@DecimalMin(value = "0", message = "최대 가격은 0 이상이어야 합니다.")
+	private BigInteger maxPrice;
+
+	@Schema(description = "최소 가격", example = "5000000")
+	@DecimalMin(value = "0", message = "최소 가격은 0 이상이어야 합니다.")
+	private BigInteger minPrice;
+
+	@Schema(description = "최소 보증금", example = "1000000")
+	@DecimalMin(value = "0", message = "최소 보증금은 0 이상이어야 합니다.")
+	private BigInteger minDeposit;
+
+	@Schema(description = "최대 보증금", example = "10000000")
+	@DecimalMax(value = "1000000000", message = "최대 보증금은 1000000000 이하여야 합니다.")
+	private BigInteger maxDeposit;
+}

--- a/src/main/java/com/zipline/dto/CustomerModifyResponseDTO.java
+++ b/src/main/java/com/zipline/dto/CustomerModifyResponseDTO.java
@@ -1,0 +1,48 @@
+package com.zipline.dto;
+
+import java.math.BigInteger;
+
+import com.zipline.entity.Customer;
+
+import lombok.Getter;
+
+@Getter
+public class CustomerModifyResponseDTO {
+	private Long uid;
+	private String name;
+	private String phoneNo;
+	private String address;
+	private String telProvider;
+	private String region;
+	private BigInteger minRent;
+	private BigInteger maxRent;
+	private String trafficSource;
+	private boolean isLandlord;
+	private boolean isTenant;
+	private boolean isBuyer;
+	private boolean isSeller;
+	private BigInteger maxPrice;
+	private BigInteger minPrice;
+	private BigInteger minDeposit;
+	private BigInteger maxDeposit;
+
+	public CustomerModifyResponseDTO(Customer customer) {
+		this.uid = customer.getUid();
+		this.name = customer.getName();
+		this.phoneNo = customer.getPhoneNo();
+		this.address = customer.getAddress();
+		this.telProvider = customer.getTelProvider();
+		this.region = customer.getRegion();
+		this.minRent = customer.getMinRent();
+		this.maxRent = customer.getMaxRent();
+		this.trafficSource = customer.getTrafficSource();
+		this.isLandlord = customer.isLandlord();
+		this.isTenant = customer.isTenant();
+		this.isBuyer = customer.isBuyer();
+		this.isSeller = customer.isSeller();
+		this.maxPrice = customer.getMaxPrice();
+		this.minPrice = customer.getMinPrice();
+		this.minDeposit = customer.getMinDeposit();
+		this.maxDeposit = customer.getMaxDeposit();
+	}
+}

--- a/src/main/java/com/zipline/dto/CustomerRegisterRequestDTO.java
+++ b/src/main/java/com/zipline/dto/CustomerRegisterRequestDTO.java
@@ -51,7 +51,7 @@ public class CustomerRegisterRequestDTO {
 	private boolean isLandlord;
 
 	@Schema(description = "임차인 여부", example = "true")
-	private boolean isLessee;
+	private boolean isTenant;
 
 	@Schema(description = "매수인 여부", example = "false")
 	private boolean isBuyer;
@@ -88,7 +88,7 @@ public class CustomerRegisterRequestDTO {
 			.maxRent(maxRent)
 			.trafficSource(trafficSource)
 			.isLandlord(isLandlord)
-			.isLandlord(isLessee)
+			.isTenant(isTenant)
 			.isBuyer(isBuyer)
 			.isSeller(isSeller)
 			.maxPrice(maxPrice)

--- a/src/main/java/com/zipline/entity/Customer.java
+++ b/src/main/java/com/zipline/entity/Customer.java
@@ -3,6 +3,10 @@ package com.zipline.entity;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
 
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.custom.customer.PriceValidationException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -118,5 +122,62 @@ public class Customer {
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
 		this.deletedAt = deletedAt;
+	}
+
+	public void modifyCustomer(String name, String phoneNo, String address, String telProvider, String region,
+		BigInteger minRent, BigInteger maxRent, String trafficSource, boolean isTenant, boolean isLandlord,
+		boolean isBuyer, boolean isSeller, BigInteger maxPrice, BigInteger minPrice, BigInteger minDeposit,
+		BigInteger maxDeposit, LocalDateTime updatedAt) {
+		validatePrices(minRent, maxRent, maxPrice, minPrice, minDeposit, maxDeposit);
+		this.name = name;
+		this.phoneNo = phoneNo;
+		this.address = address;
+		this.telProvider = telProvider;
+		this.region = region;
+		this.minRent = minRent;
+		this.maxRent = maxRent;
+		this.trafficSource = trafficSource;
+		this.isTenant = isTenant;
+		this.isLandlord = isLandlord;
+		this.isBuyer = isBuyer;
+		this.isSeller = isSeller;
+		this.minPrice = minPrice;
+		this.maxPrice = maxPrice;
+		this.minDeposit = minDeposit;
+		this.maxDeposit = maxDeposit;
+		this.updatedAt = updatedAt;
+	}
+
+	private void validatePrices(BigInteger minRent, BigInteger maxRent, BigInteger minPrice, BigInteger maxPrice,
+		BigInteger minDeposit, BigInteger maxDeposit) {
+		validateNotNegative(minRent);
+		validateNotNegative(maxRent);
+		validateNotNegative(minPrice);
+		validateNotNegative(maxPrice);
+		validateNotNegative(minDeposit);
+		validateNotNegative(maxDeposit);
+		validateRange(minRent, maxRent);
+		validateRange(minPrice, maxPrice);
+		validateRange(minDeposit, maxDeposit);
+	}
+
+	private void validateNotNegative(BigInteger price) {
+		if (price == null) {
+			return;
+		}
+
+		if (price.compareTo(BigInteger.ZERO) < 0) {
+			throw new PriceValidationException("가격은 음수일 수 없습니다.", HttpStatus.BAD_REQUEST);
+		}
+	}
+
+	private void validateRange(BigInteger min, BigInteger max) {
+		if (min == null || max == null) {
+			return;
+		}
+
+		if (min.compareTo(max) > 0) {
+			throw new PriceValidationException("최소 가격이 최대 가격보다 클 수 없습니다.", HttpStatus.BAD_REQUEST);
+		}
 	}
 }

--- a/src/main/java/com/zipline/global/exception/custom/customer/CustomerNotFoundException.java
+++ b/src/main/java/com/zipline/global/exception/custom/customer/CustomerNotFoundException.java
@@ -1,0 +1,12 @@
+package com.zipline.global.exception.custom.customer;
+
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.custom.BaseException;
+
+public class CustomerNotFoundException extends BaseException {
+
+	public CustomerNotFoundException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/custom/customer/PermissionDeniedException.java
+++ b/src/main/java/com/zipline/global/exception/custom/customer/PermissionDeniedException.java
@@ -1,0 +1,12 @@
+package com.zipline.global.exception.custom.customer;
+
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.custom.BaseException;
+
+public class PermissionDeniedException extends BaseException {
+
+	public PermissionDeniedException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/custom/customer/PriceValidationException.java
+++ b/src/main/java/com/zipline/global/exception/custom/customer/PriceValidationException.java
@@ -1,0 +1,11 @@
+package com.zipline.global.exception.custom.customer;
+
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.custom.BaseException;
+
+public class PriceValidationException extends BaseException {
+	public PriceValidationException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/repository/CustomerRepository.java
+++ b/src/main/java/com/zipline/repository/CustomerRepository.java
@@ -1,5 +1,7 @@
 package com.zipline.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.zipline.entity.Customer;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+	Optional<Customer> findByUidAndIsDeletedFalse(Long customerUid);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용
> Customer Entity - Entity 수정 로직 추가
> Customer Custom Exception 추가
> Custom PermissionDenied Exception 추가

## 💬리뷰 요구사항
> 현재 변경감지를 통해 업데이트를 진행하고 있습니다.
> 하지만, Customer의 업데이트 가능한 필드의 갯수가 많아 modifyCustomer()의 매개변수가 너무 많습니다.
> 변경감지를 사용하지 않는 방법도 좋으니 좋은 방법 있을까요?
