### PR TITLE
feat: 문자 발송 api 관련 코드 추가

### DIFF
--- a/src/main/java/com/zipline/controller/MessageController.java
+++ b/src/main/java/com/zipline/controller/MessageController.java
@@ -1,0 +1,36 @@
+package com.zipline.controller;
+
+import com.zipline.dto.SendMessageRequestDto;
+import com.zipline.service.MessageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/message")
+public class MessageController {
+
+  private final MessageService messageService;
+
+  public MessageController(MessageService messageService) {
+    this.messageService = messageService;
+  }
+
+  @PostMapping("/send")
+  public Mono<ResponseEntity<String>> sendMessage(
+      @RequestBody SendMessageRequestDto[] requestBody) {
+
+    return messageService.sendMessage(requestBody)
+        .map(ResponseEntity::ok)
+        .onErrorResume(e -> {
+          System.err.println("Error occurred while sending message: " + e.getMessage());
+
+          // 에러 발생 시 처리
+          return Mono.just(
+              ResponseEntity.status(500).body(e.toString()));
+        });
+  }
+}

--- a/src/main/java/com/zipline/dto/SendMessageRequestDto.java
+++ b/src/main/java/com/zipline/dto/SendMessageRequestDto.java
@@ -1,0 +1,11 @@
+package com.zipline.dto;
+
+import lombok.Data;
+
+@Data
+public class SendMessageRequestDto {
+
+  private String from;
+  private String to;
+  private String text;
+}

--- a/src/main/java/com/zipline/global/config/WebClientConfig.java
+++ b/src/main/java/com/zipline/global/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.zipline.global.config;
 
+import com.zipline.service.SignatureService;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -10,18 +11,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
-  
+
   @Value("${sms.api-key}")
   String apiKey;
 
   @Bean
-  public WebClient webClient() {
-    // 임시 값
-    Map<String, String> signatureResult = Map.of(
-        "time", "2025-04-01T15:29:00Z",
-        "salt", "randomSaltValue123",
-        "hash", "exampleHashValue456"
-    );
+  public WebClient webClient(SignatureService signatureService) {
+    Map<String, String> signatureResult = signatureService.generateSignature()
+        .block();
 
     if (signatureResult == null || signatureResult.isEmpty()) {
       throw new IllegalArgumentException("유효하지 않은 signature 값 입니다.");

--- a/src/main/java/com/zipline/global/config/WebClientConfig.java
+++ b/src/main/java/com/zipline/global/config/WebClientConfig.java
@@ -16,7 +16,7 @@ public class WebClientConfig {
   String apiKey;
 
   @Bean
-  public WebClient webClient(SignatureService signatureService) {
+  public WebClient smsWebClient(SignatureService signatureService) {
     Map<String, String> signatureResult = signatureService.generateSignature()
         .block();
 

--- a/src/main/java/com/zipline/global/config/WebClientConfig.java
+++ b/src/main/java/com/zipline/global/config/WebClientConfig.java
@@ -1,6 +1,6 @@
 package com.zipline.global.config;
 
-import com.zipline.service.SignatureService;
+import com.zipline.util.SignatureUtil;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +16,7 @@ public class WebClientConfig {
   String apiKey;
 
   @Bean
-  public WebClient smsWebClient(SignatureService signatureService) {
+  public WebClient smsWebClient(SignatureUtil signatureService) {
     Map<String, String> signatureResult = signatureService.generateSignature()
         .block();
 

--- a/src/main/java/com/zipline/service/MessageService.java
+++ b/src/main/java/com/zipline/service/MessageService.java
@@ -1,6 +1,7 @@
 package com.zipline.service;
 
 import com.zipline.dto.SendMessageRequestDto;
+import com.zipline.util.SignatureUtil;
 import java.util.Map;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ public class MessageService {
 
   private final WebClient webClient;
 
-  public MessageService(WebClient webClient, SignatureService signatureService) {
+  public MessageService(WebClient webClient, SignatureUtil signatureUtil) {
     this.webClient = webClient;
   }
 

--- a/src/main/java/com/zipline/service/MessageService.java
+++ b/src/main/java/com/zipline/service/MessageService.java
@@ -1,0 +1,35 @@
+package com.zipline.service;
+
+import com.zipline.dto.SendMessageRequestDto;
+import java.util.Map;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+
+@Service
+public class MessageService {
+
+  private final WebClient webClient;
+
+  public MessageService(WebClient webClient, SignatureService signatureService) {
+    this.webClient = webClient;
+  }
+
+  public Mono<String> sendMessage(SendMessageRequestDto[] request) {
+
+    Map<String, Object> wrappedRequest = Map.of("messages", request);
+
+    return webClient.post()
+        .uri("/send-many/detail")
+        .bodyValue(wrappedRequest)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            clientResponse -> clientResponse.bodyToMono(String.class).map(body -> {
+              throw new RuntimeException(body);
+            })
+        ).bodyToMono(String.class);
+  }
+}

--- a/src/main/java/com/zipline/service/SignatureService.java
+++ b/src/main/java/com/zipline/service/SignatureService.java
@@ -1,5 +1,6 @@
 package com.zipline.service;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.HashMap;
@@ -36,10 +37,11 @@ public class SignatureService {
       String authMessage = now + salt;
 
       Mac mac = Mac.getInstance(authMethod);
-      SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), authMethod);
+      SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
+          authMethod);
       mac.init(keySpec);
 
-      byte[] hmacBytes = mac.doFinal(authMessage.getBytes());
+      byte[] hmacBytes = mac.doFinal(authMessage.getBytes(StandardCharsets.UTF_8));
 
       String hash = HexUtils.toHexString(hmacBytes);
 

--- a/src/main/java/com/zipline/service/SignatureService.java
+++ b/src/main/java/com/zipline/service/SignatureService.java
@@ -1,0 +1,54 @@
+package com.zipline.service;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.tomcat.util.buf.HexUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class SignatureService {
+
+  @Value("${sms.secret-key}")
+  String secretKey;
+
+  @Value("${sms.auth-method}")
+  String authMethod;
+
+  public static String generateSalt() {
+    SecureRandom random = new SecureRandom();
+    byte[] salt = new byte[16];
+    random.nextBytes(salt);
+    return HexUtils.toHexString(salt);
+  }
+
+  public Mono<Map<String, String>> generateSignature() {
+    return Mono.fromCallable(() -> {
+      Map<String, String> result = new HashMap<>();
+
+      String now = Instant.now().toString();
+      String salt = generateSalt();
+      String authMessage = now + salt;
+
+      Mac mac = Mac.getInstance(authMethod);
+      SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), authMethod);
+      mac.init(keySpec);
+
+      byte[] hmacBytes = mac.doFinal(authMessage.getBytes());
+
+      String hash = HexUtils.toHexString(hmacBytes);
+
+      result.put("time", now);
+      result.put("salt", salt);
+      result.put("hash", hash);
+
+      return result;
+
+    }).onErrorMap(e -> new RuntimeException("signature를 생성 중 오류가 발생했습니다.", e));
+  }
+}

--- a/src/main/java/com/zipline/util/SignatureUtil.java
+++ b/src/main/java/com/zipline/util/SignatureUtil.java
@@ -1,4 +1,4 @@
-package com.zipline.service;
+package com.zipline.util;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -9,19 +9,27 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.tomcat.util.buf.HexUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-@Service
-public class SignatureService {
 
-  @Value("${sms.secret-key}")
-  String secretKey;
+public class SignatureUtil {
 
-  @Value("${sms.auth-method}")
-  String authMethod;
+  private final String secretKey;
+  private final String authMethod;
+  private final String now;
+  private final String salt;
+  private final String authMessage;
 
-  public static String generateSalt() {
+  public SignatureUtil(@Value("${sms.secret-key}") String secretKey,
+      @Value("${sms.auth-method}") String authMethod) {
+    this.secretKey = secretKey;
+    this.authMethod = authMethod;
+    this.now = Instant.now().toString();
+    this.salt = generateSalt();
+    this.authMessage = now + salt;
+  }
+
+  private static String generateSalt() {
     SecureRandom random = new SecureRandom();
     byte[] salt = new byte[16];
     random.nextBytes(salt);
@@ -31,10 +39,6 @@ public class SignatureService {
   public Mono<Map<String, String>> generateSignature() {
     return Mono.fromCallable(() -> {
       Map<String, String> result = new HashMap<>();
-
-      String now = Instant.now().toString();
-      String salt = generateSalt();
-      String authMessage = now + salt;
 
       Mac mac = Mac.getInstance(authMethod);
       SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
@@ -51,6 +55,6 @@ public class SignatureService {
 
       return result;
 
-    }).onErrorMap(e -> new RuntimeException("signature를 생성 중 오류가 발생했습니다.", e));
+    }).onErrorMap(e -> new RuntimeException("signature를 생성 중에 오류가 발생했습니다.", e));
   }
 }

--- a/src/main/java/com/zipline/util/SignatureUtil.java
+++ b/src/main/java/com/zipline/util/SignatureUtil.java
@@ -9,9 +9,10 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.tomcat.util.buf.HexUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-
+@Component
 public class SignatureUtil {
 
   private final String secretKey;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 

## 📝작업 내용
>
> 메시지 api를 사용할 때 header에 들어갈 Authorization 값을 생성하는 service를 추가했습니다. [공식 문서](https://developers.solapi.com/references/authentication/api-key)
> signature 값의 경우 현재 시간과 salt 값을 조합해서 생성하는 값입니다!



## 💬리뷰 요구사항(선택)

>
> salt 값은 상수 값으로 설정하려다가 동적으로 생성해주고 있는데 혹시 이 부분 예상되는 이슈 있으면 말씀해주세요!
