### PR TITLE
feat: 설문 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.apache.tika:tika-core:2.9.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zipline/global/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/zipline/global/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package com.zipline.global.config;
+
+import java.lang.reflect.Type;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+	public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+		super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+	}
+
+	@Override
+	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	protected boolean canWrite(MediaType mediaType) {
+		return false;
+	}
+}

--- a/src/main/java/com/zipline/global/config/S3Config.java
+++ b/src/main/java/com/zipline/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.zipline.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+	@Value("${aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3Client() {
+		AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return AmazonS3ClientBuilder
+			.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.withRegion(region)
+			.build();
+	}
+}

--- a/src/main/java/com/zipline/global/config/S3Folder.java
+++ b/src/main/java/com/zipline/global/config/S3Folder.java
@@ -1,0 +1,15 @@
+package com.zipline.global.config;
+
+public enum S3Folder {
+	SURVEYS("surveys/");
+
+	private final String folderPrefix;
+
+	S3Folder(String folderPrefix) {
+		this.folderPrefix = folderPrefix;
+	}
+
+	public String getFolderPrefix() {
+		return folderPrefix;
+	}
+}

--- a/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.zipline.global.exception;
 
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import net.minidev.json.JSONObject;
 
@@ -45,6 +47,12 @@ public class GlobalExceptionHandler {
 		ExceptionResponseDTO response = ExceptionResponseDTO.of(HttpStatus.BAD_REQUEST,
 			e.getBindingResult().getFieldError().getDefaultMessage());
 		return ResponseEntity.status(e.getStatusCode()).body(response);
+	}
+
+	@ExceptionHandler({MaxUploadSizeExceededException.class, FileSizeLimitExceededException.class})
+	public ResponseEntity<ExceptionResponseDTO> handleException(RuntimeException e) {
+		ExceptionResponseDTO response = ExceptionResponseDTO.of(HttpStatus.PAYLOAD_TOO_LARGE, "파일의 크기가 너무 큽니다.");
+		return ResponseEntity.status(response.getCode()).body(response);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/zipline/global/exception/custom/FileUploadException.java
+++ b/src/main/java/com/zipline/global/exception/custom/FileUploadException.java
@@ -1,0 +1,10 @@
+package com.zipline.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class FileUploadException extends BaseException {
+
+	public FileUploadException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/custom/QuestionNotFoundException.java
+++ b/src/main/java/com/zipline/global/exception/custom/QuestionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.zipline.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class QuestionNotFoundException extends BaseException {
+	public QuestionNotFoundException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/global/exception/custom/QuestionTypeException.java
+++ b/src/main/java/com/zipline/global/exception/custom/QuestionTypeException.java
@@ -1,0 +1,9 @@
+package com.zipline.global.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class QuestionTypeException extends BaseException {
+	public QuestionTypeException(String message, HttpStatus status) {
+		super(message, status);
+	}
+}

--- a/src/main/java/com/zipline/global/util/FileValidator.java
+++ b/src/main/java/com/zipline/global/util/FileValidator.java
@@ -1,0 +1,39 @@
+package com.zipline.global.util;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.tika.Tika;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.zipline.global.exception.custom.FileUploadException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class FileValidator {
+
+	private static final Tika tika = new Tika();
+	private final Set<String> ALLOWED_MIME_TYPES;
+
+	public FileValidator(@Value("${file.allowed-mime-types}") List<String> allowedMimeTypes) {
+		this.ALLOWED_MIME_TYPES = new HashSet<>(allowedMimeTypes);
+	}
+
+	public void validateSurveyFile(MultipartFile file) {
+		try {
+			String detect = tika.detect(file.getInputStream());
+			if (!ALLOWED_MIME_TYPES.contains(detect)) {
+				throw new FileUploadException("지원하지 않는 MIME TYPE 입니다.", HttpStatus.BAD_REQUEST);
+			}
+		} catch (IOException e) {
+			throw new FileUploadException("파일 MIME 타입 검증에 실패하였습니다.", HttpStatus.BAD_REQUEST);
+		}
+	}
+}

--- a/src/main/java/com/zipline/global/util/S3FileUploader.java
+++ b/src/main/java/com/zipline/global/util/S3FileUploader.java
@@ -1,0 +1,90 @@
+package com.zipline.global.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.zipline.global.config.S3Folder;
+import com.zipline.global.exception.custom.FileUploadException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class S3FileUploader {
+
+	@Value("${aws.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 amazonS3;
+	private final FileValidator fileValidator;
+
+	public Map<Long, String> uploadSurveyFiles(Map<Long, MultipartFile> questionUidFileMap, S3Folder s3Folder) {
+		Map<Long, String> fileUrlMap = new HashMap<>();
+
+		for (Long questionUid : questionUidFileMap.keySet()) {
+			MultipartFile file = questionUidFileMap.get(questionUid);
+			fileValidator.validateSurveyFile(file);
+			String uploadedUrl = uploadFile(file, s3Folder.getFolderPrefix());
+			fileUrlMap.put(questionUid, uploadedUrl);
+		}
+		return fileUrlMap;
+	}
+
+	public String uploadFile(MultipartFile file, String folderPrefix) {
+		String originalFileName = file.getOriginalFilename();
+		String storeFileName = createStoreFileName(originalFileName, folderPrefix);
+
+		ObjectMetadata metadata = createObjectMetadata(file);
+
+		try (InputStream inputStream = file.getInputStream()) {
+			amazonS3.putObject(new PutObjectRequest(bucket, storeFileName, inputStream, metadata));
+		} catch (IOException e) {
+			throw new FileUploadException("파일 업로드 중 오류가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
+		return amazonS3.getUrl(bucket, storeFileName).toString();
+	}
+
+	private ObjectMetadata createObjectMetadata(MultipartFile multipartFile) {
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(multipartFile.getContentType());
+		objectMetadata.setContentLength(multipartFile.getSize());
+		return objectMetadata;
+	}
+
+	private String createStoreFileName(String originalFileName, String folderName) {
+		String ext = extractExt(originalFileName);
+		String fileName = extractFileName(originalFileName);
+		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE);
+		String uuid = UUID.randomUUID().toString();
+		log.info("fileName = {} ", fileName);
+		return folderName + nowTime + fileName + uuid + "." + ext;
+	}
+
+	private String extractExt(String originalFileName) {
+		int pos = originalFileName.lastIndexOf(".");
+		String ext = originalFileName.substring(pos + 1);
+		return ext;
+	}
+
+	private String extractFileName(String originalFileName) {
+		int pos = originalFileName.lastIndexOf(".");
+		String fileName = originalFileName.substring(0, pos);
+		return fileName;
+	}
+}

--- a/src/main/java/com/zipline/survey/controller/SurveyController.java
+++ b/src/main/java/com/zipline/survey/controller/SurveyController.java
@@ -1,20 +1,25 @@
 package com.zipline.survey.controller;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.global.common.response.ApiResponse;
 import com.zipline.survey.dto.SurveyCreateRequestDTO;
 import com.zipline.survey.dto.SurveyResponseDTO;
+import com.zipline.survey.dto.SurveySubmitRequestDTO;
 import com.zipline.survey.service.SurveyService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,5 +51,14 @@ public class SurveyController {
 	public ResponseEntity<ApiResponse<SurveyResponseDTO>> getSurvey(@PathVariable Long surveyUid) {
 		ApiResponse<SurveyResponseDTO> response = surveyService.getSurvey(surveyUid);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	@PostMapping(value = "/surveys/{surveyUid}/submit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+		MediaType.APPLICATION_JSON_VALUE})
+	public ResponseEntity<ApiResponse<Void>> submitSurvey(@PathVariable Long surveyUid,
+		@RequestPart(name = "requestDTO") List<SurveySubmitRequestDTO> requestDTO,
+		@RequestPart(name = "files", required = false) List<MultipartFile> files) {
+		ApiResponse<Void> response = surveyService.submitSurvey(surveyUid, requestDTO, files);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/src/main/java/com/zipline/survey/dto/SurveySubmitRequestDTO.java
+++ b/src/main/java/com/zipline/survey/dto/SurveySubmitRequestDTO.java
@@ -1,0 +1,12 @@
+package com.zipline.survey.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class SurveySubmitRequestDTO {
+	private Long questionId;
+	private List<Long> choiceIds;
+	private String answer;
+}

--- a/src/main/java/com/zipline/survey/entity/SurveyAnswer.java
+++ b/src/main/java/com/zipline/survey/entity/SurveyAnswer.java
@@ -1,0 +1,39 @@
+package com.zipline.survey.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "survey_answers")
+@Entity
+public class SurveyAnswer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long uid;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "survey_response_uid")
+	private SurveyResponse surveyResponse;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "question_uid")
+	private Question question;
+
+	private String answer;
+
+	public SurveyAnswer(SurveyResponse surveyResponse, Question question, String answer) {
+		this.surveyResponse = surveyResponse;
+		this.question = question;
+		this.answer = answer;
+	}
+}

--- a/src/main/java/com/zipline/survey/entity/SurveyResponse.java
+++ b/src/main/java/com/zipline/survey/entity/SurveyResponse.java
@@ -1,0 +1,39 @@
+package com.zipline.survey.entity;
+
+import com.zipline.entity.Customer;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "survey_responses")
+@Entity
+public class SurveyResponse {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long uid;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "survey_uid")
+	private Survey survey;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "customer_uid")
+	private Customer customer;
+
+	public SurveyResponse(Survey survey, Customer customer) {
+		this.survey = survey;
+		this.customer = customer;
+	}
+}

--- a/src/main/java/com/zipline/survey/repository/SurveyAnswerRepository.java
+++ b/src/main/java/com/zipline/survey/repository/SurveyAnswerRepository.java
@@ -1,0 +1,8 @@
+package com.zipline.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zipline.survey.entity.SurveyAnswer;
+
+public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long> {
+}

--- a/src/main/java/com/zipline/survey/repository/SurveyResponseRepository.java
+++ b/src/main/java/com/zipline/survey/repository/SurveyResponseRepository.java
@@ -1,0 +1,8 @@
+package com.zipline.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zipline.survey.entity.SurveyResponse;
+
+public interface SurveyResponseRepository extends JpaRepository<SurveyResponse, Long> {
+}

--- a/src/main/java/com/zipline/survey/service/FileQuestionMapper.java
+++ b/src/main/java/com/zipline/survey/service/FileQuestionMapper.java
@@ -1,0 +1,47 @@
+package com.zipline.survey.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.zipline.global.exception.custom.QuestionNotFoundException;
+import com.zipline.survey.entity.Question;
+import com.zipline.survey.entity.enums.QuestionType;
+
+@Component
+public class FileQuestionMapper {
+
+	@Value("${survey.questionUid-delimiter}")
+	private String questionUidDelimiter;
+
+	public Map<Long, MultipartFile> mapFilesToQuestions(List<MultipartFile> files, List<Question> questions) {
+		Map<Long, MultipartFile> questionFileMap = new HashMap<>();
+
+		for (MultipartFile file : files) {
+			String originalFilename = file.getOriginalFilename();
+			Long extractedQuestionUid = extractQuestionUid(originalFilename, questionUidDelimiter);
+
+			validateFileUploadQuestionExists(questions, extractedQuestionUid);
+			questionFileMap.put(extractedQuestionUid, file);
+		}
+		return questionFileMap;
+	}
+
+	private void validateFileUploadQuestionExists(List<Question> questions, Long uid) {
+		if (questions.stream().noneMatch(q -> q.getUid().equals(uid)
+			&& q.getQuestionType() == QuestionType.FILE_UPLOAD)) {
+			throw new QuestionNotFoundException("파일과 매핑되는 유효한 문항이 없습니다.", HttpStatus.BAD_REQUEST);
+		}
+	}
+
+	private Long extractQuestionUid(String originalFileName, String questionUidDelimiter) {
+		int pos = originalFileName.indexOf(questionUidDelimiter);
+		Long questionUid = Long.parseLong(originalFileName.substring(0, pos));
+		return questionUid;
+	}
+}

--- a/src/main/java/com/zipline/survey/service/SurveyAnswerFactory.java
+++ b/src/main/java/com/zipline/survey/service/SurveyAnswerFactory.java
@@ -1,0 +1,52 @@
+package com.zipline.survey.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.zipline.global.exception.custom.QuestionNotFoundException;
+import com.zipline.global.exception.custom.QuestionTypeException;
+import com.zipline.survey.dto.SurveySubmitRequestDTO;
+import com.zipline.survey.entity.Question;
+import com.zipline.survey.entity.SurveyAnswer;
+import com.zipline.survey.entity.SurveyResponse;
+import com.zipline.survey.entity.enums.QuestionType;
+
+@Component
+public class SurveyAnswerFactory {
+
+	public SurveyAnswer createAnswer(SurveySubmitRequestDTO requestDTO, List<Question> questions,
+		SurveyResponse surveyResponse) {
+		Question question = findQuestionByUid(questions, requestDTO.getQuestionId());
+
+		if (question.getQuestionType() == QuestionType.SUBJECTIVE) {
+			return new SurveyAnswer(surveyResponse, question, requestDTO.getAnswer());
+		}
+		if (isChoiceQuestion(question.getQuestionType())) {
+			String choiceValue = String.join(",", requestDTO.getChoiceIds().stream()
+				.map(String::valueOf)
+				.collect(Collectors.toList()));
+			return new SurveyAnswer(surveyResponse, question, choiceValue);
+		}
+		throw new QuestionTypeException("지원하지 않는 질문 타입입니다.", HttpStatus.BAD_REQUEST);
+	}
+
+	public SurveyAnswer createFileAnswer(Long questionUid, String fileUrl, List<Question> questions,
+		SurveyResponse response) {
+		Question question = findQuestionByUid(questions, questionUid);
+		return new SurveyAnswer(response, question, fileUrl);
+	}
+
+	private Question findQuestionByUid(List<Question> questions, Long uid) {
+		return questions.stream()
+			.filter(q -> q.getUid().equals(uid))
+			.findFirst()
+			.orElseThrow(() -> new QuestionNotFoundException("해당하는 문항이 없습니다.", HttpStatus.BAD_REQUEST));
+	}
+
+	private boolean isChoiceQuestion(QuestionType questionType) {
+		return questionType == QuestionType.MULTIPLE_CHOICE || questionType == QuestionType.SINGLE_CHOICE;
+	}
+}

--- a/src/main/java/com/zipline/survey/service/SurveyService.java
+++ b/src/main/java/com/zipline/survey/service/SurveyService.java
@@ -1,28 +1,38 @@
 package com.zipline.survey.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.entity.User;
 import com.zipline.global.common.response.ApiResponse;
+import com.zipline.global.config.S3Folder;
 import com.zipline.global.exception.custom.SurveyNotFoundException;
 import com.zipline.global.exception.custom.UserNotFoundException;
+import com.zipline.global.util.S3FileUploader;
 import com.zipline.repository.UserRepository;
 import com.zipline.survey.dto.SurveyCreateRequestDTO;
 import com.zipline.survey.dto.SurveyResponseDTO;
+import com.zipline.survey.dto.SurveySubmitRequestDTO;
 import com.zipline.survey.entity.Choice;
 import com.zipline.survey.entity.Question;
 import com.zipline.survey.entity.Survey;
+import com.zipline.survey.entity.SurveyAnswer;
+import com.zipline.survey.entity.SurveyResponse;
 import com.zipline.survey.entity.enums.QuestionType;
 import com.zipline.survey.entity.enums.SurveyStatus;
 import com.zipline.survey.repository.QuestionRepository;
+import com.zipline.survey.repository.SurveyAnswerRepository;
 import com.zipline.survey.repository.SurveyRepository;
+import com.zipline.survey.repository.SurveyResponseRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +43,11 @@ public class SurveyService {
 	private final SurveyRepository surveyRepository;
 	private final UserRepository userRepository;
 	private final QuestionRepository questionRepository;
+	private final SurveyAnswerRepository surveyAnswerRepository;
+	private final SurveyResponseRepository surveyResponseRepository;
+	private final S3FileUploader s3FileUploader;
+	private final FileQuestionMapper fileQuestionMapper;
+	private final SurveyAnswerFactory surveyAnswerFactory;
 
 	@Transactional
 	public ApiResponse<Map<String, Long>> createSurvey(SurveyCreateRequestDTO requestDTO, Long agentUID) {
@@ -62,5 +77,36 @@ public class SurveyService {
 		List<Question> questions = questionRepository.findAllBySurveyUidWithChoices(savedSurvey.getUid());
 		SurveyResponseDTO result = SurveyResponseDTO.from(savedSurvey, questions);
 		return ApiResponse.ok("설문 조회 성공", result);
+	}
+
+	@Transactional
+	public ApiResponse<Void> submitSurvey(Long surveyUid, List<SurveySubmitRequestDTO> requestDTOList,
+		List<MultipartFile> files) {
+		Survey savedSurvey = surveyRepository.findByUidAndStatus(surveyUid, SurveyStatus.ACTIVE)
+			.orElseThrow(() -> new SurveyNotFoundException("해당하는 설문이 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
+
+		SurveyResponse surveyResponse = new SurveyResponse(savedSurvey, null);
+		surveyResponseRepository.save(surveyResponse);
+		List<Question> questions = questionRepository.findAllBySurveyUidWithChoices(savedSurvey.getUid());
+
+		List<SurveyAnswer> generalAnswers = requestDTOList.stream()
+			.map(dto -> surveyAnswerFactory.createAnswer(dto, questions, surveyResponse))
+			.collect(Collectors.toList());
+
+		Map<Long, MultipartFile> questionUidFileMap = fileQuestionMapper.mapFilesToQuestions(files, questions);
+		Map<Long, String> questionUidUploadedUrlMap = s3FileUploader.uploadSurveyFiles(questionUidFileMap,
+			S3Folder.SURVEYS);
+
+		List<SurveyAnswer> fileAnswers = questionUidUploadedUrlMap.entrySet()
+			.stream()
+			.map(entry -> surveyAnswerFactory.createFileAnswer(entry.getKey(), entry.getValue(), questions,
+				surveyResponse))
+			.collect(Collectors.toList());
+
+		List<SurveyAnswer> allAnswers = new ArrayList<>();
+		allAnswers.addAll(generalAnswers);
+		allAnswers.addAll(fileAnswers);
+		surveyAnswerRepository.saveAll(allAnswers);
+		return ApiResponse.create("설문 제출에 성공하였습니다.");
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61 

## 📝작업 내용
> 설문 제출 시 첨부된 파일을 문항 UID 기준으로 매핑하는 로직 구현
>> 파일명에서 UID 추출 ({questionUid}_파일명.확장자 형식)
>> UID에 해당하는 문항이 존재하고 파일 업로드 타입인지 검증

> S3FileUploader 유틸 클래스를 통해 파일을 S3에 업로드하고 URL 반환 처리
>> 업로드 시 폴더 구조 및 파일명 UUID 기반으로 관리
>> 유효하지 않은 파일 확장자 및 크기에 대한 유효성 검증 포함

> SurveyAnswerFactory에 파일형 질문 타입에 대한 응답 생성 로직 추가
>> 기존 응답 생성 방식과 동일한 방식으로 SurveyAnswer 생성

> SurveyService.submitSurvey에서 일반 응답과 파일 응답을 함께 처리
>> 제출 시 모든 응답을 하나의 리스트로 병합하여 저장 처리

> 예외 상황에 대한 커스텀 예외 처리 추가
>> 유효하지 않은 문항 UID 또는 문항 타입 오류 발생 시 예외 반환
