### PR TITLE
(fix)cicd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
 
   deploy:
     needs: test
-    #if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
 
   deploy:
     needs: test
-    if: github.event_name == 'push' #&& github.ref == 'refs/heads/dev'
+    #if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
 
   deploy:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    if: github.event_name == 'push' #&& github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,10 +57,9 @@ jobs:
             sudo docker rm -f ${{ secrets.PROJECT_NAME }} || true
             sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }} || true
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-            # Run the container with all environment variables
-            sudo docker run -d -p ${{ secrets.PORT }}:${{ secrets.PORT }} \
-            --name ${{ secrets.PROJECT_NAME }} \
-            --env-file <(cat <<EOL
+            
+            # 환경 파일 생성
+            cat << 'EOF' > /tmp/docker-env-vars
             PORT=${{ secrets.PORT }}
             DB_PORT=${{ secrets.DB_PORT }}
             DB_NAME=${{ secrets.DB_NAME }}
@@ -95,6 +94,13 @@ jobs:
             SMS_SEC_KEY=${{ secrets.SMS_SEC_KEY }}
             SURVEY_DELIMITER=${{ secrets.SURVEY_DELIMITER }}
             SPRING_PROFILES_ACTIVE=dev
-            EOL
-            ) \
+            EOF
+            
+            #환경 파일로 도커 실행 
+            sudo docker run -d -p ${{ secrets.PORT }}:${{ secrets.PORT }} \
+            --name ${{ secrets.PROJECT_NAME }} \
+            --env-file /tmp/docker-env-vars \
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
+            
+            # Clean up the environment file
+            rm /tmp/docker-env-vars


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #105 

## 📝작업 내용
>도커 내부에서 cat EOF 를 실행할 디렉토리가 없어서 정상 작동되지 않았습니다.
아마존 리눅스에서 환경파일을 만들어서 해당 파일로 도커를 실행시키고 해당파일을 삭제하는 쪽으로 스크립트를 수정했습니다.
>dev에 머지 없이 테스트 할 수 있도록 배포 조건을 완화했습니다.
