### PR TITLE
chore: role에 따른 요청 가능한 api 규칙 수정

### DIFF
--- a/src/main/java/com/zipline/global/config/SecurityConfig.java
+++ b/src/main/java/com/zipline/global/config/SecurityConfig.java
@@ -1,5 +1,12 @@
 package com.zipline.global.config;
 
+import com.zipline.global.jwt.JwtFilter;
+import com.zipline.global.jwt.TokenProvider;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,71 +19,62 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
-import com.zipline.global.jwt.JwtFilter;
-import com.zipline.global.jwt.TokenProvider;
-
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import lombok.RequiredArgsConstructor;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final TokenProvider jwtTokenProvider;
-	private final RedisTemplate<String, String> redisTemplate;
+  private final TokenProvider jwtTokenProvider;
+  private final RedisTemplate<String, String> redisTemplate;
 
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
-	@Bean
-	public OpenAPI customOpenAPI() {
-		return new OpenAPI()
-			.addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
-			.components(new Components()
-				.addSecuritySchemes("BearerAuth",
-					new SecurityScheme()
-						.name("Authorization")
-						.type(SecurityScheme.Type.HTTP)
-						.scheme("bearer")
-						.bearerFormat("JWT")
-				));
-	}
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+        .components(new Components()
+            .addSecuritySchemes("BearerAuth",
+                new SecurityScheme()
+                    .name("Authorization")
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+            ));
+  }
 
-	@Bean
-	public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
-		http
-			.csrf(csrf -> csrf.disable())
-			.formLogin(form -> form.disable())
-			.cors(cors -> cors.configure(http))
-			.sessionManagement(
-				session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/users/login", "/api/users/signup", "/api/users/me",
-					"/api/users/reissue")
-				.permitAll()
-				.requestMatchers(new RegexRequestMatcher("/api/surveys/\\d+$", "GET"),
-					new RegexRequestMatcher("/api/surveys/\\d+/submit$", "POST"))
-				.permitAll()
-				.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs",
-					"/api-docs/**",
-					"/v3/api-docs/**")
-				.permitAll()
-				.requestMatchers("/api/admin/**")
-				.hasRole("ADMIN")
-				.requestMatchers("/api/**")
-				.hasRole("AGENT")
-				.anyRequest()
-				.authenticated()
-			)
-			.addFilterBefore(new JwtFilter(jwtTokenProvider, redisTemplate),
-				UsernamePasswordAuthenticationFilter.class);
+  @Bean
+  public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(csrf -> csrf.disable())
+        .formLogin(form -> form.disable())
+        .cors(cors -> cors.configure(http))
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/users/login", "/api/users/signup", "/api/users/me",
+                "/api/users/reissue")
+            .permitAll()
+            .requestMatchers(new RegexRequestMatcher("/api/surveys/\\d+$", "GET"),
+                new RegexRequestMatcher("/api/surveys/\\d+/submit$", "POST"))
+            .permitAll()
+            .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs",
+                "/api-docs/**",
+                "/v3/api-docs/**")
+            .permitAll()
+            .requestMatchers("/api/admin/**")
+            .hasRole("ADMIN")
+            .requestMatchers("/api/**")
+            .hasAnyRole("AGENT", "ADMIN")
+            .anyRequest()
+            .authenticated()
+        )
+        .addFilterBefore(new JwtFilter(jwtTokenProvider, redisTemplate),
+            UsernamePasswordAuthenticationFilter.class);
 
-		return http.build();
-	}
+    return http.build();
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #134 

## 📝작업 내용

### BEFORE

```
            .requestMatchers("/api/admin/**")
            .hasRole("ADMIN")
            .requestMatchers("/api/**")
            .hasRole("AGENT")
```

### AFTER

```
            .requestMatchers("/api/admin/**")
            .hasRole("ADMIN")
            .requestMatchers("/api/**")
            .hasAnyRole("AGENT", "ADMIN")
```

## 📸 스크린샷 (선택)

<img width="785" alt="스크린샷 2025-04-10 오후 4 34 16" src="https://github.com/user-attachments/assets/57cfa950-df47-4f3d-bc93-9bc0d7d28f7d" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
