### PR TITLE
feat: 아이디 찾기 기능 구현

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/config/SecurityConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/SecurityConfig.java
@@ -1,12 +1,5 @@
 package com.zipline.global.config;
 
-import com.zipline.global.jwt.JwtFilter;
-import com.zipline.global.jwt.TokenProvider;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,62 +12,71 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
+import com.zipline.global.jwt.JwtFilter;
+import com.zipline.global.jwt.TokenProvider;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final TokenProvider jwtTokenProvider;
-  private final RedisTemplate<String, String> redisTemplate;
+	private final TokenProvider jwtTokenProvider;
+	private final RedisTemplate<String, String> redisTemplate;
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
-  @Bean
-  public OpenAPI customOpenAPI() {
-    return new OpenAPI()
-        .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
-        .components(new Components()
-            .addSecuritySchemes("BearerAuth",
-                new SecurityScheme()
-                    .name("Authorization")
-                    .type(SecurityScheme.Type.HTTP)
-                    .scheme("bearer")
-                    .bearerFormat("JWT")
-            ));
-  }
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+			.components(new Components()
+				.addSecuritySchemes("BearerAuth",
+					new SecurityScheme()
+						.name("Authorization")
+						.type(SecurityScheme.Type.HTTP)
+						.scheme("bearer")
+						.bearerFormat("JWT")
+				));
+	}
 
-  @Bean
-  public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
-    http
-        .csrf(csrf -> csrf.disable())
-        .formLogin(form -> form.disable())
-        .cors(cors -> cors.configure(http))
-        .sessionManagement(
-            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/users/login", "/api/users/signup", "/api/users/me",
-                "/api/users/reissue")
-            .permitAll()
-            .requestMatchers(new RegexRequestMatcher("/api/surveys/\\d+$", "GET"),
-                new RegexRequestMatcher("/api/surveys/\\d+/submit$", "POST"))
-            .permitAll()
-            .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs",
-                "/api-docs/**",
-                "/v3/api-docs/**")
-            .permitAll()
-            .requestMatchers("/api/admin/**")
-            .hasRole("ADMIN")
-            .requestMatchers("/api/**")
-            .hasAnyRole("AGENT", "ADMIN")
-            .anyRequest()
-            .authenticated()
-        )
-        .addFilterBefore(new JwtFilter(jwtTokenProvider, redisTemplate),
-            UsernamePasswordAuthenticationFilter.class);
+	@Bean
+	public SecurityFilterChain userFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.formLogin(form -> form.disable())
+			.cors(cors -> cors.configure(http))
+			.sessionManagement(
+				session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/users/login", "/api/users/signup", "/api/users/me",
+					"/api/users/reissue", "/api/users/find-id")
+				.permitAll()
+				.requestMatchers(new RegexRequestMatcher("/api/surveys/\\d+$", "GET"),
+					new RegexRequestMatcher("/api/surveys/\\d+/submit$", "POST"))
+				.permitAll()
+				.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs",
+					"/api-docs/**",
+					"/v3/api-docs/**")
+				.permitAll()
+				.requestMatchers("/api/admin/**")
+				.hasRole("ADMIN")
+				.requestMatchers("/api/**")
+				.hasAnyRole("AGENT", "ADMIN")
+				.anyRequest()
+				.authenticated()
+			)
+			.addFilterBefore(new JwtFilter(jwtTokenProvider, redisTemplate),
+				UsernamePasswordAuthenticationFilter.class);
 
-    return http.build();
-  }
+		return http.build();
+	}
 }

--- a/apiserver/controller/src/main/java/com/zipline/controller/user/UserController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/user/UserController.java
@@ -28,6 +28,7 @@ import com.zipline.global.response.ApiResponse;
 import com.zipline.service.user.UserService;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -115,7 +116,7 @@ public class UserController {
 
 	@PostMapping("/find-id")
 	public ResponseEntity<ApiResponse<FindUserIdResponseDTO>> findUserId(
-		@RequestBody FindUserIdRequestDTO findUserIdRequestDto) {
+		@RequestBody @Valid FindUserIdRequestDTO findUserIdRequestDto) {
 		FindUserIdResponseDTO findUserId = userService.findUserId(findUserIdRequestDto);
 		ApiResponse<FindUserIdResponseDTO> response = ApiResponse.create("아이디 찾기 성공", findUserId);
 		return ResponseEntity.ok(response);

--- a/apiserver/controller/src/main/java/com/zipline/controller/user/UserController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/user/UserController.java
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.zipline.dto.TokenResponseDTO;
-import com.zipline.dto.UserRequestDTO;
-import com.zipline.dto.UserResponseDTO;
+import com.zipline.dto.user.FindUserIdRequestDTO;
+import com.zipline.dto.user.FindUserIdResponseDTO;
+import com.zipline.dto.user.TokenResponseDTO;
+import com.zipline.dto.user.UserRequestDTO;
+import com.zipline.dto.user.UserResponseDTO;
 import com.zipline.global.jwt.dto.TokenRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.user.UserService;
@@ -108,6 +110,14 @@ public class UserController {
 		UserResponseDTO updatedInfo = userService.updateInfo(uid, userRequestDto);
 
 		ApiResponse<UserResponseDTO> response = ApiResponse.ok("회원 정보 수정 완료", updatedInfo);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/find-id")
+	public ResponseEntity<ApiResponse<FindUserIdResponseDTO>> findUserId(
+		@RequestBody FindUserIdRequestDTO findUserIdRequestDto) {
+		FindUserIdResponseDTO findUserId = userService.findUserId(findUserIdRequestDto);
+		ApiResponse<FindUserIdResponseDTO> response = ApiResponse.create("아이디 찾기 성공", findUserId);
 		return ResponseEntity.ok(response);
 	}
 

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdRequestDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdRequestDTO.java
@@ -1,0 +1,17 @@
+package com.zipline.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "아이디 찾기 요청 DTO")
+@AllArgsConstructor
+@Getter
+public class FindUserIdRequestDTO {
+
+	@Schema(description = "회원 이름", example = "홍길동")
+	private final String name;
+
+	@Schema(description = "회원 이메일", example = "honggildong@example.com")
+	private final String email;
+}

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdRequestDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdRequestDTO.java
@@ -1,6 +1,10 @@
 package com.zipline.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,8 +14,14 @@ import lombok.Getter;
 public class FindUserIdRequestDTO {
 
 	@Schema(description = "회원 이름", example = "홍길동")
+	@NotBlank(message = "이름을 입력해주세요.")
+	@Size(min = 2, max = 255, message = "이름은 2자 이상 255자 이하로 입력해주세요.")
+	@Pattern(regexp = "^[a-zA-Z가-힣]+$", message = "이름에는 특수문자나 숫자를 포함할 수 없습니다.")
 	private final String name;
 
 	@Schema(description = "회원 이메일", example = "honggildong@example.com")
+	@NotBlank(message = "이메일을 입력해주세요.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@Size(max = 320, message = "이메일은 최대 320자까지 입력 가능합니다.")
 	private final String email;
 }

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdResponseDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdResponseDTO.java
@@ -1,18 +1,12 @@
 package com.zipline.dto.user;
 
-import com.zipline.entity.user.User;
-
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class FindUserIdResponseDTO {
 	private String id;
 
-	public static FindUserIdResponseDTO findId(User user) {
-		return FindUserIdResponseDTO.builder()
-			.id(user.getId())
-			.build();
+	public FindUserIdResponseDTO(String id) {
+		this.id = id;
 	}
 }

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdResponseDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/FindUserIdResponseDTO.java
@@ -1,0 +1,18 @@
+package com.zipline.dto.user;
+
+import com.zipline.entity.user.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindUserIdResponseDTO {
+	private String id;
+
+	public static FindUserIdResponseDTO findId(User user) {
+		return FindUserIdResponseDTO.builder()
+			.id(user.getId())
+			.build();
+	}
+}

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/TokenRequestDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/TokenRequestDTO.java
@@ -1,4 +1,4 @@
-package com.zipline.dto;
+package com.zipline.dto.user;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/TokenResponseDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/TokenResponseDTO.java
@@ -1,4 +1,4 @@
-package com.zipline.dto;
+package com.zipline.dto.user;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/UserRequestDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/UserRequestDTO.java
@@ -1,4 +1,4 @@
-package com.zipline.dto;
+package com.zipline.dto.user;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 

--- a/apiserver/domain/src/main/java/com/zipline/dto/user/UserResponseDTO.java
+++ b/apiserver/domain/src/main/java/com/zipline/dto/user/UserResponseDTO.java
@@ -1,9 +1,10 @@
-package com.zipline.dto;
+package com.zipline.dto.user;
 
 import java.time.LocalDateTime;
 
 import com.zipline.entity.survey.Survey;
 import com.zipline.entity.user.User;
+
 import lombok.Builder;
 import lombok.Getter;
 

--- a/apiserver/domain/src/main/java/com/zipline/entity/user/User.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/user/User.java
@@ -1,6 +1,6 @@
 package com.zipline.entity.user;
 
-import com.zipline.dto.UserRequestDTO;
+import com.zipline.dto.user.UserRequestDTO;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/UserRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/UserRepository.java
@@ -2,15 +2,17 @@ package com.zipline.repository;
 
 import java.util.Optional;
 
-import com.zipline.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.zipline.entity.user.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT user FROM User user WHERE user.id = :id")
 	Optional<User> findByLoginId(@Param("id") String id);
+
+	Optional<User> findByNameAndEmail(String name, String email);
 
 	boolean existsById(String id);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/user/UserService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/user/UserService.java
@@ -1,7 +1,9 @@
 package com.zipline.service.user;
 
-import com.zipline.dto.UserRequestDTO;
-import com.zipline.dto.UserResponseDTO;
+import com.zipline.dto.user.FindUserIdRequestDTO;
+import com.zipline.dto.user.FindUserIdResponseDTO;
+import com.zipline.dto.user.UserRequestDTO;
+import com.zipline.dto.user.UserResponseDTO;
 import com.zipline.global.jwt.dto.TokenRequestDTO;
 
 public interface UserService {
@@ -17,4 +19,6 @@ public interface UserService {
 	UserResponseDTO updateInfo(Long uid, UserRequestDTO userRequestDto);
 
 	TokenRequestDTO reissue(String refreshToken);
+
+	FindUserIdResponseDTO findUserId(FindUserIdRequestDTO findUserIdRequestDto);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/user/UserServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/user/UserServiceImpl.java
@@ -187,6 +187,6 @@ public class UserServiceImpl implements UserService {
 			findUserIdRequestDto.getEmail()
 		).orElseThrow(() -> new UserNotFoundException("일치하는 사용자가 없습니다.", HttpStatus.BAD_REQUEST));
 
-		return FindUserIdResponseDTO.findId(user);
+		return new FindUserIdResponseDTO(user.getId());
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/user/UserServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/user/UserServiceImpl.java
@@ -14,8 +14,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.zipline.dto.UserRequestDTO;
-import com.zipline.dto.UserResponseDTO;
+import com.zipline.dto.user.FindUserIdRequestDTO;
+import com.zipline.dto.user.FindUserIdResponseDTO;
+import com.zipline.dto.user.UserRequestDTO;
+import com.zipline.dto.user.UserResponseDTO;
 import com.zipline.entity.survey.Survey;
 import com.zipline.entity.user.Authority;
 import com.zipline.entity.user.User;
@@ -83,7 +85,6 @@ public class UserServiceImpl implements UserService {
 
 	@Transactional
 	public TokenRequestDTO login(UserRequestDTO userRequestDto) {
-
 		// 0. 입력값 null 체크
 		if (userRequestDto.getId().isBlank() || userRequestDto.getPassword().isBlank()) {
 			throw new UserNotFoundException("아이디와 비밀번호를 모두 입력해주세요.", HttpStatus.BAD_REQUEST);
@@ -179,4 +180,13 @@ public class UserServiceImpl implements UserService {
 		return tokenRequestDto;
 	}
 
+	@Transactional(readOnly = true)
+	public FindUserIdResponseDTO findUserId(FindUserIdRequestDTO findUserIdRequestDto) {
+		User user = userRepository.findByNameAndEmail(
+			findUserIdRequestDto.getName(),
+			findUserIdRequestDto.getEmail()
+		).orElseThrow(() -> new UserNotFoundException("일치하는 사용자가 없습니다.", HttpStatus.BAD_REQUEST));
+
+		return FindUserIdResponseDTO.findId(user);
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #169

## 📝작업 내용
> SecurityConfig - permitAll에 "/api/users/find-id" 추가
> UserController - find-id API 추가
> UserRepository - user의 이름과 email 반환 메서드 추가
> UserServiceImpl - 이름과 email 비교 후 아이디 반환하는 메서드 추가
> 아이디 찾기 요청, 응답 DTO 생성

> user 관련 dto -> user 폴더로 이동
