### PR TITLE
fix: 설문 생성 시 Validation 버그 수정

### DIFF
--- a/apiserver/service/src/main/java/com/zipline/service/survey/dto/request/QuestionValidator.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/dto/request/QuestionValidator.java
@@ -16,73 +16,130 @@ public class QuestionValidator
 		.map(Enum::name)
 		.collect(Collectors.toCollection(HashSet::new));
 
+	private static final String TITLE_MIN_LENGTH_ERROR_MSG = "문항 제목의 최소 길이는 1자 입니다.";
+	private static final String TITLE_MAX_LENGTH_ERROR_MSG = "문항 제목의 최대 길이는 20자 입니다.";
+	private static final String TYPE_REQUIRED_ERROR_MSG = "문항의 타입은 필수입니다.";
+	private static final String IS_REQUIRED_ERROR_MSG = "문항의 required 여부는 필수값입니다.";
+	private static final String INVALID_TYPE_ERROR_MSG = "유효하지 않은 문항 타입입니다";
+	private static final String DESCRIPTION_MIN_LENGTH_ERROR_MSG = "문항 설명의 최소 길이는 1자 입니다.";
+	private static final String DESCRIPTION_MAX_LENGTH_ERROR_MSG = "문항 설명의 최대 길이는 %d자 입니다.";
+	private static final String CHOICE_REQUIRED_ERROR_MSG = "객관식 문항은 최소 1개의 선택지를 포함해야 합니다.";
+	private static final String CHOICE_NOT_ALLOWED_ERROR_MSG = "객관식이 아닌 문항에는 선택지를 추가할 수 없습니다.";
+	private static final String MULTIPLE_CHOICE_MIN_COUNT_ERROR_MSG = "객관식 복수 선택 문항은 최소 3개의 선택지를 포함해야 합니다.";
+
+	private static final int TITLE_MAX_LENGTH = 20;
+	private static final int CHOICE_DESCRIPTION_MAX_LENGTH = 30;
+	private static final int SUBJECTIVE_DESCRIPTION_MAX_LENGTH = 200;
+	private static final int MULTIPLE_CHOICE_MIN_CHOICES_COUNT = 3;
+
 	@Override
 	public boolean isValid(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
 		ConstraintValidatorContext constraintValidatorContext) {
 
-		if (!QUESTION_TYPES_SET.contains(questionRequestDTO.getType())) {
-			constraintValidatorContext.disableDefaultConstraintViolation();
-			constraintValidatorContext.buildConstraintViolationWithTemplate("유효하지 않은 문항 타입입니다")
-				.addConstraintViolation();
+		return validateTitle(questionRequestDTO, constraintValidatorContext)
+			&& validateType(questionRequestDTO, constraintValidatorContext)
+			&& validateIsRequired(questionRequestDTO, constraintValidatorContext)
+			&& validateQuestionType(questionRequestDTO, constraintValidatorContext)
+			&& validateDescription(questionRequestDTO, constraintValidatorContext)
+			&& validateChoices(questionRequestDTO, constraintValidatorContext);
+	}
+
+	private boolean validateTitle(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		if (questionRequestDTO.getTitle() == null || questionRequestDTO.getTitle().trim().isEmpty()) {
+			addConstraintViolation(context, TITLE_MIN_LENGTH_ERROR_MSG);
 			return false;
 		}
-
-		int max = getMaxLengthByType(questionRequestDTO.getType());
-		if (questionRequestDTO.getDescription().length() > max) {
-			constraintValidatorContext.disableDefaultConstraintViolation();
-			constraintValidatorContext.buildConstraintViolationWithTemplate("문항 설명의 최대 길이는 " + max + "자 입니다.")
-				.addConstraintViolation();
+		if (questionRequestDTO.getTitle().length() > TITLE_MAX_LENGTH) {
+			addConstraintViolation(context, TITLE_MAX_LENGTH_ERROR_MSG);
 			return false;
-		}
-
-		// 객관식 질문 (선택지 필수)
-		if (isChoiceQuestion(questionRequestDTO.getType())) {
-			if (questionRequestDTO.getChoices().isEmpty()) {
-				constraintValidatorContext.disableDefaultConstraintViolation();
-				constraintValidatorContext.buildConstraintViolationWithTemplate("객관식 문항은 최소 1개의 선택지를 포함해야 합니다.")
-					.addConstraintViolation();
-				return false;
-			}
-		}
-
-		if (!isChoiceQuestion(questionRequestDTO.getType())) {
-			if (!questionRequestDTO.getChoices().isEmpty()) {
-				constraintValidatorContext.disableDefaultConstraintViolation();
-				constraintValidatorContext.buildConstraintViolationWithTemplate("객관식이 아닌 문항에는 선택지를 추가할 수 없습니다.")
-					.addConstraintViolation();
-				return false;
-			}
-		}
-
-		if (isMultipleChoiceQuestion(questionRequestDTO.getType())) {
-			if (questionRequestDTO.getChoices().size() < 3) {
-				constraintValidatorContext.disableDefaultConstraintViolation();
-				constraintValidatorContext.buildConstraintViolationWithTemplate("객관식 복수 선택 문항은 최소 3개의 선택지를 포함해야 합니다.")
-					.addConstraintViolation();
-				return false;
-			}
 		}
 		return true;
 	}
 
+	private boolean validateType(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		if (questionRequestDTO.getType() == null || questionRequestDTO.getType().trim().isEmpty()) {
+			addConstraintViolation(context, TYPE_REQUIRED_ERROR_MSG);
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateIsRequired(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		if (questionRequestDTO.getIsRequired() == null) {
+			addConstraintViolation(context, IS_REQUIRED_ERROR_MSG);
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateQuestionType(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		if (!QUESTION_TYPES_SET.contains(questionRequestDTO.getType())) {
+			addConstraintViolation(context, INVALID_TYPE_ERROR_MSG);
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateDescription(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		if (questionRequestDTO.getDescription() == null || questionRequestDTO.getDescription().trim().isEmpty()) {
+			addConstraintViolation(context, DESCRIPTION_MIN_LENGTH_ERROR_MSG);
+			return false;
+		}
+
+		int maxLength = getMaxLengthByType(questionRequestDTO.getType());
+		if (questionRequestDTO.getDescription().length() > maxLength) {
+			addConstraintViolation(context, String.format(DESCRIPTION_MAX_LENGTH_ERROR_MSG, maxLength));
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validateChoices(SurveyCreateRequestDTO.QuestionRequestDTO questionRequestDTO,
+		ConstraintValidatorContext context) {
+		String type = questionRequestDTO.getType();
+
+		if (isChoiceQuestion(type)) {
+			if (questionRequestDTO.getChoices().isEmpty()) {
+				addConstraintViolation(context, CHOICE_REQUIRED_ERROR_MSG);
+				return false;
+			}
+
+			if (isMultipleChoiceQuestion(type)
+				&& questionRequestDTO.getChoices().size() < MULTIPLE_CHOICE_MIN_CHOICES_COUNT) {
+				addConstraintViolation(context, MULTIPLE_CHOICE_MIN_COUNT_ERROR_MSG);
+				return false;
+			}
+		} else if (!questionRequestDTO.getChoices().isEmpty()) {
+			addConstraintViolation(context, CHOICE_NOT_ALLOWED_ERROR_MSG);
+			return false;
+		}
+		return true;
+	}
+
+	private void addConstraintViolation(ConstraintValidatorContext context, String message) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(message)
+			.addConstraintViolation();
+	}
+
 	private int getMaxLengthByType(String questionType) {
 		if (isChoiceQuestion(questionType)) {
-			return 30;
+			return CHOICE_DESCRIPTION_MAX_LENGTH;
 		}
-		return 200;
+		return SUBJECTIVE_DESCRIPTION_MAX_LENGTH;
 	}
 
 	private boolean isChoiceQuestion(String questionType) {
-		if (questionType.equals("MULTIPLE_CHOICE") || questionType.equals("SINGLE_CHOICE")) {
-			return true;
-		}
-		return false;
+		return QuestionType.SINGLE_CHOICE.name().equals(questionType) || QuestionType.MULTIPLE_CHOICE.name()
+			.equals(questionType);
 	}
 
 	private boolean isMultipleChoiceQuestion(String questionType) {
-		if (questionType.equals("MULTIPLE_CHOICE")) {
-			return true;
-		}
-		return false;
+		return QuestionType.MULTIPLE_CHOICE.name().equals(questionType);
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/survey/dto/request/SurveyCreateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/dto/request/SurveyCreateRequestDTO.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -31,21 +30,16 @@ public class SurveyCreateRequestDTO {
 	@QuestionValidate
 	public static class QuestionRequestDTO {
 		@Schema(description = "문항 제목", example = "관심 매물의 종류")
-		@Size(max = 20, message = "문항 제목의 최대 길이는 20자 입니다.")
-		@NotBlank(message = "문항 제목의 최소 길이는 1자 입니다.")
 		private String title;
 
 		@Schema(description = "문항 설명", example = "선택지 중 하나를 골라주세요.")
-		@NotBlank(message = "문항 설명의 최소 길이는 1자 입니다.")
 		private String description;
 
-		@NotBlank(message = "문항의 타입은 필수입니다.")
 		@Schema(description = "문항 타입", example = "SINGLE_CHOICE", allowableValues = {"SINGLE_CHOICE", "MULTIPLE_CHOICE",
 			"SUBJECTIVE", "FILE_UPLOAD"})
 		private String type;
 
 		@Schema(description = "필수 응답 여부", example = "true")
-		@NotNull(message = "문항의 required 여부는 필수값입니다.")
 		private Boolean isRequired;
 
 		@ArraySchema(schema = @Schema(description = "문항 선택지 목록", implementation = ChoiceRequestDTO.class))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #184 

## 📝작업 내용
> 설문 생성 요청시 Custom Validator, Default Validation Annotion을 혼용하여 사용할 경우 Default Validation이 적용되지 않는 현상 발생 
-  Default Validator Annotation 제거 후 CustomValidator에서 Default Validator 로직(NotNull, NotBlank 등) 구현
> CostomValidator Code Refactoring 진행
