### PR TITLE
(feat) 설문 생성 시 URL에 대체키를 사용하도록 변경

### DIFF
--- a/apiserver/common/build.gradle
+++ b/apiserver/common/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // ULID
+    implementation("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0")
 }
 
 tasks.named('test') {

--- a/apiserver/common/src/main/java/com/zipline/global/util/ULIDGenerator.java
+++ b/apiserver/common/src/main/java/com/zipline/global/util/ULIDGenerator.java
@@ -1,0 +1,17 @@
+package com.zipline.global.util;
+
+import org.springframework.stereotype.Component;
+
+import de.huxhorn.sulky.ulid.ULID;
+
+@Component
+public class ULIDGenerator {
+	private static final ULID ulid = new ULID();
+
+	public static String generate() {
+		return ulid.nextULID();
+	}
+
+	private ULIDGenerator() {
+	}
+}

--- a/apiserver/controller/src/main/java/com/zipline/ApiServerApplication.java
+++ b/apiserver/controller/src/main/java/com/zipline/ApiServerApplication.java
@@ -2,11 +2,13 @@ package com.zipline;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ApiServerApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(ApiServerApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ApiServerApplication.class, args);
+	}
 }
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/survey/SurveyController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/survey/SurveyController.java
@@ -42,11 +42,12 @@ public class SurveyController {
 
 	@Operation(summary = "설문 생성", description = "새로운 설문을 생성합니다.")
 	@PostMapping("/surveys")
-	public ResponseEntity<ApiResponse<Map<String, Long>>> createSurvey(
+	public ResponseEntity<ApiResponse<Map<String, String>>> createSurvey(
 		@Valid @RequestBody SurveyCreateRequestDTO requestDTO,
 		Principal principal) {
-		ApiResponse<Map<String, Long>> response = surveyService.createSurvey(requestDTO,
+		Map<String, String> result = surveyService.createSurvey(requestDTO,
 			Long.parseLong(principal.getName()));
+		ApiResponse<Map<String, String>> response = ApiResponse.create("설문 등록 완료", result);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 

--- a/apiserver/domain/src/main/java/com/zipline/entity/enums/SurveyStatus.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/enums/SurveyStatus.java
@@ -1,5 +1,0 @@
-package com.zipline.entity.enums;
-
-public enum SurveyStatus {
-	ACTIVE, CLOSED
-}

--- a/apiserver/domain/src/main/java/com/zipline/entity/survey/Survey.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/survey/Survey.java
@@ -1,17 +1,15 @@
 package com.zipline.entity.survey;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.zipline.entity.enums.SurveyStatus;
+import com.zipline.entity.BaseTimeEntity;
 import com.zipline.entity.user.User;
+import com.zipline.global.util.ULIDGenerator;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -28,7 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "surveys")
 @Entity
-public class Survey {
+public class Survey extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,21 +44,18 @@ public class Survey {
 	@OneToMany(mappedBy = "survey", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
 	private List<Question> questions = new ArrayList<>();
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "status", nullable = false)
-	private SurveyStatus status;
+	@Column(name = "ulid", length = 26, unique = true, nullable = false)
+	private String ulid;
 
-	@Column(name = "created_at", nullable = false)
-	private LocalDateTime createdAt;
+	@PrePersist
+	private void generateULID() {
+		if (ulid == null || ulid.isBlank()) {
+			this.ulid = ULIDGenerator.generate();
+		}
+	}
 
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	public Survey(String title, User user, SurveyStatus status, LocalDateTime createdAt, LocalDateTime deletedAt) {
+	public Survey(String title, User user) {
 		this.title = title;
 		this.user = user;
-		this.status = status;
-		this.createdAt = createdAt;
-		this.deletedAt = deletedAt;
 	}
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
@@ -2,13 +2,12 @@ package com.zipline.repository.survey;
 
 import java.util.Optional;
 
-import com.zipline.entity.enums.SurveyStatus;
-import com.zipline.entity.survey.Survey;
-import com.zipline.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.zipline.entity.survey.Survey;
+import com.zipline.entity.user.User;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
@@ -2,18 +2,21 @@ package com.zipline.repository.survey;
 
 import java.util.Optional;
 
+import com.zipline.entity.enums.SurveyStatus;
+import com.zipline.entity.survey.Survey;
+import com.zipline.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import com.zipline.entity.enums.SurveyStatus;
-import com.zipline.entity.survey.Survey;
-import com.zipline.entity.user.User;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
-	@Query("SELECT s FROM Survey s WHERE s.uid = :surveyUID AND s.status = :status")
-	Optional<Survey> findByUidAndStatus(Long surveyUID, SurveyStatus status);
+	@Query("SELECT s FROM Survey s WHERE s.uid = :surveyUid AND s.deletedAt IS NULL")
+	Optional<Survey> findByUidAndDeletedAtIsNull(Long surveyUid);
+
+	@Query("SELECT s FROM Survey s WHERE s.user.uid = :userUid AND s.deletedAt IS NULL")
+	Optional<Survey> findByUserUidAndDeletedAtIsNull(Long userUid);
 
 	Optional<Survey> findFirstByUserOrderByCreatedAtDesc(User user);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/survey/SurveyService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/SurveyService.java
@@ -16,7 +16,7 @@ import com.zipline.service.survey.dto.response.SurveyResponseListDTO;
 
 public interface SurveyService {
 
-	ApiResponse<Map<String, Long>> createSurvey(SurveyCreateRequestDTO requestDTO, Long agentUID);
+	Map<String, String> createSurvey(SurveyCreateRequestDTO requestDTO, Long agentUID);
 
 	void createDefaultSurveyForUser(User user);
 

--- a/apiserver/service/src/main/java/com/zipline/service/survey/SurveyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/SurveyServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.entity.enums.QuestionType;
-import com.zipline.entity.enums.SurveyStatus;
 import com.zipline.entity.survey.Choice;
 import com.zipline.entity.survey.Question;
 import com.zipline.entity.survey.Survey;
@@ -22,6 +21,12 @@ import com.zipline.entity.survey.SurveyAnswer;
 import com.zipline.entity.survey.SurveyResponse;
 import com.zipline.entity.user.User;
 import com.zipline.global.config.S3Folder;
+import com.zipline.global.exception.auth.AuthException;
+import com.zipline.global.exception.auth.errorcode.AuthErrorCode;
+import com.zipline.global.exception.survey.SurveyException;
+import com.zipline.global.exception.survey.errorcode.SurveyErrorCode;
+import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.global.util.S3FileUploader;
@@ -52,10 +57,10 @@ public class SurveyServiceImpl implements SurveyService {
 	private final SurveyAnswerFactory surveyAnswerFactory;
 
 	@Transactional
-	public ApiResponse<Map<String, Long>> createSurvey(SurveyCreateRequestDTO requestDTO, Long agentUID) {
+	public Map<String, String> createSurvey(SurveyCreateRequestDTO requestDTO, Long agentUID) {
 		User user = userRepository.findById(agentUID)
-			.orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST));
-		Survey survey = new Survey(requestDTO.getTitle(), user, SurveyStatus.ACTIVE, LocalDateTime.now(), null);
+			.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+		Survey survey = new Survey(requestDTO.getTitle(), user);
 
 		requestDTO.getQuestions().forEach(questionDTO -> {
 			Question question = new Question(questionDTO.getTitle(), QuestionType.valueOf(questionDTO.getType()),
@@ -69,12 +74,12 @@ public class SurveyServiceImpl implements SurveyService {
 		});
 		surveyRepository.save(survey);
 		user.setUrl(String.valueOf(survey.getUid()));
-		return ApiResponse.create("설문 등록 완료", Collections.singletonMap("surveyURL", survey.getUid()));
+		return Collections.singletonMap("surveyURL", survey.getUlid());
 	}
 
 	@Transactional
 	public void createDefaultSurveyForUser(User user) {     //default questions
-		Survey survey = new Survey("기본 설문지", user, SurveyStatus.ACTIVE, LocalDateTime.now(), null);
+		Survey survey = new Survey("기본 설문지", user);
 
 		Question nameQuestion = new Question(
 			"이름",
@@ -101,8 +106,8 @@ public class SurveyServiceImpl implements SurveyService {
 
 	@Transactional(readOnly = true)
 	public ApiResponse<SurveyResponseDTO> getSurvey(Long surveyUID) {
-		Survey savedSurvey = surveyRepository.findByUidAndStatus(surveyUID, SurveyStatus.ACTIVE)
-			.orElseThrow(() -> new SurveyNotFoundException("해당하는 설문이 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
+		Survey savedSurvey = surveyRepository.findByUidAndDeletedAtIsNull(surveyUID)
+			.orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
 		List<Question> questions = questionRepository.findAllBySurveyUidWithChoices(savedSurvey.getUid());
 		SurveyResponseDTO result = SurveyResponseDTO.from(savedSurvey, questions);
 		return ApiResponse.ok("설문 조회 성공", result);
@@ -111,8 +116,8 @@ public class SurveyServiceImpl implements SurveyService {
 	@Transactional
 	public ApiResponse<Void> submitSurvey(Long surveyUid, List<SurveySubmitRequestDTO> requestDTOList,
 		List<MultipartFile> files) {
-		Survey savedSurvey = surveyRepository.findByUidAndStatus(surveyUid, SurveyStatus.ACTIVE)
-			.orElseThrow(() -> new SurveyNotFoundException("해당하는 설문이 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
+		Survey savedSurvey = surveyRepository.findByUidAndDeletedAtIsNull(surveyUid)
+			.orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
 
 		SurveyResponse surveyResponse = new SurveyResponse(savedSurvey, null, LocalDateTime.now());
 		surveyResponseRepository.save(surveyResponse);
@@ -170,10 +175,10 @@ public class SurveyServiceImpl implements SurveyService {
 	public ApiResponse<SurveyResponseDetailDTO> getSubmittedSurvey(Long surveyResponseUid, Long userUid) {
 		SurveyResponse savedSurveyResponse = surveyResponseRepository.findSurveyResponseWithSurveyAndUserById(
 				surveyResponseUid)
-			.orElseThrow(() -> new SurveyNotFoundException("해당하는 설문 응답이 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
+			.orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
 
 		if (!savedSurveyResponse.getSurvey().getUser().getUid().equals(userUid)) {
-			throw new PermissionDeniedException("권한이 없습니다.", HttpStatus.FORBIDDEN);
+			throw new AuthException(AuthErrorCode.PERMISSION_DENIED);
 		}
 
 		List<SurveyAnswer> surveyAnswers = surveyAnswerRepository.findByWithQuestionsAndChoicesSurveyResponseUid(

--- a/apiserver/service/src/main/java/com/zipline/service/survey/dto/response/SurveyResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/dto/response/SurveyResponseDTO.java
@@ -14,7 +14,6 @@ public class SurveyResponseDTO {
 	private Long id;
 	private Long userId;
 	private String title;
-	private String status;
 	private LocalDateTime createdAt;
 	private List<QuestionResponseDTO> questions;
 
@@ -22,7 +21,6 @@ public class SurveyResponseDTO {
 		this.id = survey.getUid();
 		this.userId = survey.getUser().getUid();
 		this.title = survey.getTitle();
-		this.status = survey.getStatus().name();
 		this.createdAt = survey.getCreatedAt();
 		this.questions = questions;
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #190

## 📝작업 내용
> 기존의 설문 생성 시, 공개 URL에 Survey를 노출 -> ULID를 생성하여 대체키로 사용 및 URL에 노출하도록 변경
> 설문 생성 시 기존의 설문 Soft Delete 처리 로직 추가
