### PR TITLE
feat: 문자 발송 내역 조회 api 추가

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/config/SmsWebClientConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/SmsWebClientConfig.java
@@ -1,7 +1,7 @@
 package com.zipline.global.config;
 
+import com.zipline.global.util.SmsSignatureGenerator;
 import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,32 +9,31 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import com.zipline.service.message.SmsSignatureGenerator;
 
 @Configuration
 public class SmsWebClientConfig {
 
-	@Value("${sms.api-key}")
-	String apiKey;
+  @Value("${sms.api-key}")
+  String apiKey;
 
-	@Bean
-	public WebClient webClient(SmsSignatureGenerator smsSignatureGenerator) {
-		Map<String, String> signatureResult = smsSignatureGenerator.generateSignature().block();
+  @Bean
+  public WebClient webClient(SmsSignatureGenerator smsSignatureGenerator) {
+    Map<String, String> signatureResult = smsSignatureGenerator.generateSignature().block();
 
-		if (signatureResult == null || signatureResult.isEmpty()) {
-			throw new IllegalArgumentException("유효하지 않은 signature 값 입니다.");
-		}
+    if (signatureResult == null || signatureResult.isEmpty()) {
+      throw new IllegalArgumentException("유효하지 않은 signature 값 입니다.");
+    }
 
-		String authorizationHeader = String.format(
-			"HMAC-SHA256 apiKey=%s, date=%s, salt=%s, signature=%s",
-			apiKey, signatureResult.get("time"), signatureResult.get("salt"),
-			signatureResult.get("hash")
-		);
+    String authorizationHeader = String.format(
+        "HMAC-SHA256 apiKey=%s, date=%s, salt=%s, signature=%s",
+        apiKey, signatureResult.get("time"), signatureResult.get("salt"),
+        signatureResult.get("hash")
+    );
 
-		return WebClient.builder()
-			.baseUrl("https://api.solapi.com/messages/v4")
-			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-			.defaultHeader(HttpHeaders.AUTHORIZATION, authorizationHeader)
-			.build();
-	}
+    return WebClient.builder()
+        .baseUrl("https://api.solapi.com/messages/v4")
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, authorizationHeader)
+        .build();
+  }
 }

--- a/apiserver/common/src/main/java/com/zipline/global/config/SmsWebClientConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/SmsWebClientConfig.java
@@ -1,39 +1,48 @@
 package com.zipline.global.config;
 
 import com.zipline.global.util.SmsSignatureGenerator;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
 
 @Configuration
 public class SmsWebClientConfig {
 
+  private final SmsSignatureGenerator smsSignatureGenerator;
   @Value("${sms.api-key}")
   String apiKey;
 
+  public SmsWebClientConfig(SmsSignatureGenerator smsSignatureGenerator) {
+    this.smsSignatureGenerator = smsSignatureGenerator;
+  }
+
   @Bean
-  public WebClient webClient(SmsSignatureGenerator smsSignatureGenerator) {
-    Map<String, String> signatureResult = smsSignatureGenerator.generateSignature().block();
-
-    if (signatureResult == null || signatureResult.isEmpty()) {
-      throw new IllegalArgumentException("유효하지 않은 signature 값 입니다.");
-    }
-
-    String authorizationHeader = String.format(
-        "HMAC-SHA256 apiKey=%s, date=%s, salt=%s, signature=%s",
-        apiKey, signatureResult.get("time"), signatureResult.get("salt"),
-        signatureResult.get("hash")
-    );
-
+  public WebClient webClient() {
     return WebClient.builder()
         .baseUrl("https://api.solapi.com/messages/v4")
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        .defaultHeader(HttpHeaders.AUTHORIZATION, authorizationHeader)
+        .filter(ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+          return smsSignatureGenerator.generateSignature()
+              .map(signatureResult -> {
+                String authorizationHeader = String.format(
+                    "HMAC-SHA256 apiKey=%s, date=%s, salt=%s, signature=%s",
+                    apiKey,
+                    signatureResult.get("time"),
+                    signatureResult.get("salt"),
+                    signatureResult.get("hash")
+                );
+
+                return ClientRequest.from(clientRequest)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .build();
+              });
+        }))
         .build();
   }
 }

--- a/apiserver/common/src/main/java/com/zipline/global/exception/message/errorcode/MessageErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/message/errorcode/MessageErrorCode.java
@@ -5,8 +5,9 @@ import org.springframework.http.HttpStatus;
 import com.zipline.global.exception.ErrorCode;
 
 public enum MessageErrorCode implements ErrorCode {
-	MESSAGE_SEND_FAILED("MSG-001", "메시지 전송에 실패하였습니다.", HttpStatus.BAD_GATEWAY);
-
+	MESSAGE_SEND_FAILED("MSG-001", "메시지 전송에 실패하였습니다.", HttpStatus.BAD_GATEWAY),
+	MESSAGE_HISTORY_INTERNAL_FAILED("MSG-002", "메시지 전송 목록을 가져오는데에 실패하였습니다.",  HttpStatus.BAD_REQUEST),
+	MESSAGE_HISTORY_EXTERNAL_FAILED("MSG-003", "메시지 전송 목록을 가져오는데에 실패하였습니다.",  HttpStatus.BAD_GATEWAY);
 	private final String code;
 	private final String message;
 	private final HttpStatus status;

--- a/apiserver/common/src/main/java/com/zipline/global/util/SmsSignatureGenerator.java
+++ b/apiserver/common/src/main/java/com/zipline/global/util/SmsSignatureGenerator.java
@@ -1,4 +1,4 @@
-package com.zipline.service.message;
+package com.zipline.global.util;
 
 import java.security.SecureRandom;
 import java.time.Instant;

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -1,11 +1,13 @@
 package com.zipline.controller.message;
 
+import com.zipline.global.response.ApiResponse;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.MessageService;
 import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,8 +42,9 @@ public class MessageController {
         .value(value)
         .build();
 
-    Object result = messageService.getMessageHistory(requestDTO);
-    return ResponseEntity.ok(result);
+    ApiResponse<MessageHistoryResponseDTO> result = ApiResponse.ok("문자 발송 내역 조회에 성공했습니다.",
+        messageService.getMessageHistory(requestDTO));
+    return ResponseEntity.status(HttpStatus.OK).body(result);
   }
 
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -1,7 +1,5 @@
 package com.zipline.controller.message;
 
-import com.zipline.entity.enums.MessageType;
-;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.MessageService;
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api/v1/messages")

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -1,6 +1,6 @@
 package com.zipline.controller.message;
 
-import com.zipline.service.message.dto.message.request.SendMessageRequestDTO;
+import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.MessageService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -6,6 +6,7 @@ import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.MessageService;
 import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,13 +29,15 @@ public class MessageController {
   }
 
   @PostMapping("")
-  public ResponseEntity<String> sendMessage(@RequestBody List<SendMessageRequestDTO> request) {
-      String result = messageService.sendMessage(request);
-      return ResponseEntity.ok(result);
+  public ResponseEntity<String> sendMessage(@RequestBody List<SendMessageRequestDTO> request,
+      Principal principal) {
+    String result = messageService.sendMessage(request, Long.parseLong(principal.getName()));
+    return ResponseEntity.ok(result);
   }
 
   @GetMapping("")
-  public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria, @RequestParam(required = false) String cond, @RequestParam(required = false) String value) {
+  public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria,
+      @RequestParam(required = false) String cond, @RequestParam(required = false) String value) {
 
     MessageHistoryRequestDTO requestDTO = MessageHistoryRequestDTO.builder()
         .criteria(criteria)

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -11,10 +11,10 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,18 +36,9 @@ public class MessageController {
   }
 
   @GetMapping("")
-  public ResponseEntity<ApiResponse<MessageHistoryResponseDTO>> getMessageHistory(@RequestParam(required = false) String criteria,
-      @RequestParam(required = false) String cond, @RequestParam(required = false) String value,
-      @RequestParam(required = false) String startKey , @RequestParam(required = false) Integer limit ,Principal principal) {
-
-    MessageHistoryRequestDTO requestDTO = MessageHistoryRequestDTO.builder()
-        .criteria(criteria)
-        .cond(cond)
-        .value(value)
-        .limit(limit)
-        .startKey(startKey)
-        .build();
-
+  public ResponseEntity<ApiResponse<MessageHistoryResponseDTO>> getMessageHistory(@ModelAttribute MessageHistoryRequestDTO requestDTO,
+Principal principal) {
+    
     ApiResponse<MessageHistoryResponseDTO> result = ApiResponse.ok("문자 발송 내역 조회에 성공했습니다.",
         messageService.getMessageHistory(requestDTO, Long.parseLong(principal.getName())));
     return ResponseEntity.status(HttpStatus.OK).body(result);

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -37,12 +37,15 @@ public class MessageController {
 
   @GetMapping("")
   public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria,
-      @RequestParam(required = false) String cond, @RequestParam(required = false) String value, Principal principal) {
+      @RequestParam(required = false) String cond, @RequestParam(required = false) String value,
+      @RequestParam(required = false) String startKey , @RequestParam(required = false) Integer limit ,Principal principal) {
 
     MessageHistoryRequestDTO requestDTO = MessageHistoryRequestDTO.builder()
         .criteria(criteria)
         .cond(cond)
         .value(value)
+        .limit(limit)
+        .startKey(startKey)
         .build();
 
     ApiResponse<MessageHistoryResponseDTO> result = ApiResponse.ok("문자 발송 내역 조회에 성공했습니다.",

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -1,9 +1,9 @@
 package com.zipline.controller.message;
 
 import com.zipline.global.response.ApiResponse;
+import com.zipline.service.message.MessageService;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
-import com.zipline.service.message.MessageService;
 import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
@@ -36,7 +36,7 @@ public class MessageController {
   }
 
   @GetMapping("")
-  public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria,
+  public ResponseEntity<ApiResponse<MessageHistoryResponseDTO>> getMessageHistory(@RequestParam(required = false) String criteria,
       @RequestParam(required = false) String cond, @RequestParam(required = false) String value,
       @RequestParam(required = false) String startKey , @RequestParam(required = false) Integer limit ,Principal principal) {
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -1,13 +1,19 @@
 package com.zipline.controller.message;
 
+import com.zipline.entity.enums.MessageType;
+;
+import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.MessageService;
+import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,4 +33,19 @@ public class MessageController {
       String result = messageService.sendMessage(request);
       return ResponseEntity.ok(result);
   }
+
+  @GetMapping("")
+  public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria, @RequestParam(required = false) String cond, @RequestParam(required = false) String value) {
+
+    MessageHistoryRequestDTO requestDTO = MessageHistoryRequestDTO.builder()
+        .criteria(criteria)
+        .cond(cond)
+        .value(value)
+        .build();
+
+    Object result = messageService.getMessageHistory(requestDTO);
+    return ResponseEntity.ok(result);
+  }
+
+
 }

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageController.java
@@ -37,7 +37,7 @@ public class MessageController {
 
   @GetMapping("")
   public ResponseEntity<Object> getMessageHistory(@RequestParam(required = false) String criteria,
-      @RequestParam(required = false) String cond, @RequestParam(required = false) String value) {
+      @RequestParam(required = false) String cond, @RequestParam(required = false) String value, Principal principal) {
 
     MessageHistoryRequestDTO requestDTO = MessageHistoryRequestDTO.builder()
         .criteria(criteria)
@@ -46,7 +46,7 @@ public class MessageController {
         .build();
 
     ApiResponse<MessageHistoryResponseDTO> result = ApiResponse.ok("문자 발송 내역 조회에 성공했습니다.",
-        messageService.getMessageHistory(requestDTO));
+        messageService.getMessageHistory(requestDTO, Long.parseLong(principal.getName())));
     return ResponseEntity.status(HttpStatus.OK).body(result);
   }
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
@@ -1,6 +1,6 @@
 package com.zipline.controller.message;
 
-import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
+import com.zipline.service.message.dto.request.MessageTemplateRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.message.MessageTemplateService;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/apiserver/domain/src/main/java/com/zipline/entity/message/MessageHistory.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/message/MessageHistory.java
@@ -1,0 +1,38 @@
+package com.zipline.entity.message;
+
+import com.zipline.entity.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "message_histories")
+@Entity
+public class MessageHistory {
+
+  @Id
+  private String groupUid;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private LocalDateTime deletedAt;
+
+  @Builder
+  public MessageHistory(String groupUid,
+      User user, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    this.groupUid = groupUid;
+    this.user = user;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/apiserver/domain/src/main/java/com/zipline/entity/message/MessageHistory.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/message/MessageHistory.java
@@ -1,5 +1,6 @@
 package com.zipline.entity.message;
 
+import com.zipline.entity.BaseTimeEntity;
 import com.zipline.entity.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,25 +15,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "message_histories")
 @Entity
-public class MessageHistory {
-
+public class MessageHistory extends BaseTimeEntity {
   @Id
   private String groupUid;
 
   @ManyToOne(fetch = FetchType.LAZY)
   private User user;
 
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
-  private LocalDateTime deletedAt;
-
   @Builder
-  public MessageHistory(String groupUid,
-      User user, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+  public MessageHistory(String groupUid, User user, LocalDateTime createdAt,
+      LocalDateTime updatedAt, LocalDateTime deletedAt) {
     this.groupUid = groupUid;
     this.user = user;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.deletedAt = deletedAt;
   }
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageHistoryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.zipline.repository.message;
+
+import com.zipline.entity.message.MessageHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageHistoryRepository extends JpaRepository<MessageHistory, Long> {
+
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageHistoryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageHistoryRepository.java
@@ -1,8 +1,13 @@
 package com.zipline.repository.message;
 
 import com.zipline.entity.message.MessageHistory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageHistoryRepository extends JpaRepository<MessageHistory, Long> {
+  @Query("SELECT m.groupUid FROM MessageHistory m WHERE m.user.uid = :userUID")
+  List<String> findGroupUidsByUserId(@Param("userUID") Long userUID);
 
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
@@ -1,7 +1,6 @@
 package com.zipline.service.message;
 
 
-import com.zipline.repository.message.MessageHistoryRepository;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import java.util.HashMap;
 import java.util.List;
@@ -15,12 +14,10 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 
 public class MessageHistoryParamFormatter {
-  private final MessageHistoryRepository messageHistoryRepository;
 
-  public Map<String, String> formatQueryParams(MessageHistoryRequestDTO requestDTO, Long userUID) {
+  public Map<String, String> formatQueryParams(MessageHistoryRequestDTO requestDTO, List<String> userGroupIds) {
     Map<String, String> queryParams = new HashMap<>();
 
-    List<String> userGroupIds = messageHistoryRepository.findGroupUidsByUserId(userUID);
 
     // 기존 검색 조건 처리
     StringBuilder criteriaBuilder = new StringBuilder();

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
@@ -1,0 +1,30 @@
+package com.zipline.service.message;
+
+
+import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+
+@Component
+public class MessageHistoryParamFormatter {
+  public Map<String, String> formatQueryParams(MessageHistoryRequestDTO requestDTO) {
+    Map<String, String> queryParams = new HashMap<>();
+
+    if (StringUtils.hasText(requestDTO.getCriteria())) {
+      queryParams.put("criteria", requestDTO.getCriteria());
+    }
+
+    if (StringUtils.hasText(requestDTO.getCond())) {
+      queryParams.put("cond", requestDTO.getCond());
+    }
+
+    if (StringUtils.hasText(requestDTO.getValue())) {
+      queryParams.put("value", requestDTO.getValue());
+    }
+
+    return queryParams;
+  }
+}

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
@@ -1,29 +1,54 @@
 package com.zipline.service.message;
 
 
+import com.zipline.repository.message.MessageHistoryRepository;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 
 @Component
+@RequiredArgsConstructor
+
 public class MessageHistoryParamFormatter {
-  public Map<String, String> formatQueryParams(MessageHistoryRequestDTO requestDTO) {
+  private final MessageHistoryRepository messageHistoryRepository;
+
+  public Map<String, String> formatQueryParams(MessageHistoryRequestDTO requestDTO, Long userUID) {
     Map<String, String> queryParams = new HashMap<>();
 
+    List<String> userGroupIds = messageHistoryRepository.findGroupUidsByUserId(userUID);
+
+    // 기존 검색 조건 처리
+    StringBuilder criteriaBuilder = new StringBuilder();
+    StringBuilder condBuilder = new StringBuilder();
+    StringBuilder valueBuilder = new StringBuilder();
+
+    // 기존 검색 조건이 있다면 추가
     if (StringUtils.hasText(requestDTO.getCriteria())) {
-      queryParams.put("criteria", requestDTO.getCriteria());
+      criteriaBuilder.append(requestDTO.getCriteria());
+      condBuilder.append(requestDTO.getCond());
+      valueBuilder.append(requestDTO.getValue());
     }
 
-    if (StringUtils.hasText(requestDTO.getCond())) {
-      queryParams.put("cond", requestDTO.getCond());
+// 각 groupId에 대한 검색 조건 추가
+    for (String groupId : userGroupIds) {
+      if (!criteriaBuilder.isEmpty()) {
+        criteriaBuilder.append(",");
+        condBuilder.append(",");
+        valueBuilder.append(",");
+      }
+      criteriaBuilder.append("groupId");
+      condBuilder.append("eq");
+      valueBuilder.append(groupId);
     }
 
-    if (StringUtils.hasText(requestDTO.getValue())) {
-      queryParams.put("value", requestDTO.getValue());
-    }
+    queryParams.put("criteria", criteriaBuilder.toString());
+    queryParams.put("cond", condBuilder.toString());
+    queryParams.put("value", valueBuilder.toString());
 
     return queryParams;
   }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageHistoryParamFormatter.java
@@ -46,6 +46,14 @@ public class MessageHistoryParamFormatter {
       valueBuilder.append(groupId);
     }
 
+    if(requestDTO.getLimit() != null && requestDTO.getLimit() > 0) {
+      queryParams.put("limit", String.valueOf(requestDTO.getLimit()));
+    }
+
+    if(requestDTO.getStartKey() != null && !requestDTO.getStartKey().isEmpty()) {
+      queryParams.put("startKey", requestDTO.getStartKey());
+    }
+
     queryParams.put("criteria", criteriaBuilder.toString());
     queryParams.put("cond", condBuilder.toString());
     queryParams.put("value", valueBuilder.toString());

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
@@ -1,8 +1,11 @@
 package com.zipline.service.message;
 
+import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
+import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import java.util.List;
 
 public interface MessageService {
   String sendMessage(List<SendMessageRequestDTO> request);
+  MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO request);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
@@ -1,6 +1,6 @@
 package com.zipline.service.message;
 
-import com.zipline.service.message.dto.message.request.SendMessageRequestDTO;
+import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import java.util.List;
 
 public interface MessageService {

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
@@ -6,6 +6,10 @@ import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import java.util.List;
 
 public interface MessageService {
-  String sendMessage(List<SendMessageRequestDTO> request);
+
+  void saveMessageHistory(String messageGroupId, Long userUID);
+
+  String sendMessage(List<SendMessageRequestDTO> request, Long userUID);
+
   MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO request);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageService.java
@@ -11,5 +11,5 @@ public interface MessageService {
 
   String sendMessage(List<SendMessageRequestDTO> request, Long userUID);
 
-  MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO request);
+  MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO request, Long userUID);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -67,13 +67,14 @@ public class MessageServiceImpl implements MessageService {
       return response;
 
     } catch (Exception e) {
+      log.info(e.getMessage());
       throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
     }
   }
 
-  public MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO requestDTO) {
+  public MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO requestDTO, Long userUID) {
     try {
-      Map<String, String> queryParams = messageHistoryParamFormatter.formatQueryParams(requestDTO);
+      Map<String, String> queryParams = messageHistoryParamFormatter.formatQueryParams(requestDTO, userUID);
 
       return webClient.get()
           .uri(uriBuilder -> {

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -2,7 +2,9 @@ package com.zipline.service.message;
 
 import com.zipline.global.exception.message.MessageException;
 import com.zipline.global.exception.message.errorcode.MessageErrorCode;
+import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
+import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class MessageServiceImpl implements MessageService {
 
   private final WebClient webClient;
+  private final MessageHistoryParamFormatter messageHistoryParamFormatter;
 
   public String sendMessage(List<SendMessageRequestDTO> request) {
 
@@ -34,6 +37,37 @@ public class MessageServiceImpl implements MessageService {
 
     } catch (Exception e) {
       throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
+    }
+  }
+
+  public MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO requestDTO) {
+    try {
+      Map<String, String> queryParams = messageHistoryParamFormatter.formatQueryParams(requestDTO);
+
+      return webClient.get()
+          .uri(uriBuilder -> {
+            uriBuilder.path("/list-old/");
+            queryParams.forEach(uriBuilder::queryParam);
+            return uriBuilder.build();
+          })
+          .retrieve()
+          .onStatus(
+              // 외부 api 에러 메세지 리턴용
+              status -> status.is4xxClientError() || status.is5xxServerError(),
+              clientResponse -> clientResponse.bodyToMono(String.class)
+                  .handle((errorBody, sink) -> {
+                    log.error("Error response from external API: {}", errorBody);
+                    sink.error(new MessageCommonException(
+                        "External API error: " + errorBody,
+                        (HttpStatus) clientResponse.statusCode()
+                    ));
+                  })
+          )
+          .bodyToMono(MessageHistoryResponseDTO.class)
+          .block();
+    } catch (Exception e) {
+      throw new MessageCommonException("메세지 발송 내역 조회 실패: " + e.getMessage(),
+          HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -1,15 +1,24 @@
 package com.zipline.service.message;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zipline.entity.message.MessageHistory;
+import com.zipline.entity.user.User;
 import com.zipline.global.exception.message.MessageException;
 import com.zipline.global.exception.message.errorcode.MessageErrorCode;
+import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
+import com.zipline.repository.message.MessageHistoryRepository;
+import com.zipline.repository.user.UserRepository;
 import com.zipline.service.message.dto.request.MessageHistoryRequestDTO;
 import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import com.zipline.service.message.dto.response.MessageHistoryResponseDTO;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
@@ -19,8 +28,25 @@ public class MessageServiceImpl implements MessageService {
 
   private final WebClient webClient;
   private final MessageHistoryParamFormatter messageHistoryParamFormatter;
+  private final MessageHistoryRepository messageHistoryRepository;
+  private final UserRepository userRepository;
 
-  public String sendMessage(List<SendMessageRequestDTO> request) {
+
+  public void saveMessageHistory(String messageGroupId, Long userUID) {
+    User loginedUser = userRepository.findById(userUID)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+    MessageHistory messageHistory = MessageHistory.builder()
+        .groupUid(messageGroupId)
+        .user(loginedUser)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    messageHistoryRepository.save(messageHistory);
+  }
+
+  @Transactional
+  public String sendMessage(List<SendMessageRequestDTO> request, Long userUID) {
 
     try {
       Map<String, Object> wrappedRequest = Map.of("messages", request);
@@ -32,7 +58,12 @@ public class MessageServiceImpl implements MessageService {
           .bodyToMono(String.class)
           .block();
 
+      ObjectMapper objectMapper = new ObjectMapper();
+      String groupId = objectMapper.readTree(response).path("groupInfo").path("_id").asText();
+
+      saveMessageHistory(groupId, userUID);
       log.info("메시지 전송 성공: {} 개의 메시지", request.size());
+
       return response;
 
     } catch (Exception e) {
@@ -52,22 +83,17 @@ public class MessageServiceImpl implements MessageService {
           })
           .retrieve()
           .onStatus(
-              // 외부 api 에러 메세지 리턴용
               status -> status.is4xxClientError() || status.is5xxServerError(),
               clientResponse -> clientResponse.bodyToMono(String.class)
                   .handle((errorBody, sink) -> {
                     log.error("Error response from external API: {}", errorBody);
-                    sink.error(new MessageCommonException(
-                        "External API error: " + errorBody,
-                        (HttpStatus) clientResponse.statusCode()
-                    ));
+                    sink.error(new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED));
                   })
           )
           .bodyToMono(MessageHistoryResponseDTO.class)
           .block();
     } catch (Exception e) {
-      throw new MessageCommonException("메세지 발송 내역 조회 실패: " + e.getMessage(),
-          HttpStatus.BAD_REQUEST);
+      throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
     }
   }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -74,11 +74,17 @@ public class MessageServiceImpl implements MessageService {
 
   public MessageHistoryResponseDTO getMessageHistory(MessageHistoryRequestDTO requestDTO, Long userUID) {
     try {
-      Map<String, String> queryParams = messageHistoryParamFormatter.formatQueryParams(requestDTO, userUID);
+      List<String> userGroupIds = messageHistoryRepository.findGroupUidsByUserId(userUID);
+
+      if (userGroupIds.isEmpty()) {
+        return MessageHistoryResponseDTO.emptyResponse();
+      }
+
+      Map<String, String> queryParams = messageHistoryParamFormatter.formatQueryParams(requestDTO, userGroupIds);
 
       return webClient.get()
           .uri(uriBuilder -> {
-            uriBuilder.path("/list-old/");
+            uriBuilder.path("/groups/");
             queryParams.forEach(uriBuilder::queryParam);
             return uriBuilder.build();
           })

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -1,42 +1,39 @@
 package com.zipline.service.message;
 
+import com.zipline.global.exception.message.MessageException;
+import com.zipline.global.exception.message.errorcode.MessageErrorCode;
+import com.zipline.service.message.dto.request.SendMessageRequestDTO;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-
-import com.zipline.global.exception.message.errorcode.MessageErrorCode;
-import com.zipline.global.exception.message.MessageException;
-import com.zipline.service.message.dto.message.request.SendMessageRequestDTO;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class MessageServiceImpl implements MessageService {
 
-	private final WebClient webClient;
+  private final WebClient webClient;
 
-	public String sendMessage(List<SendMessageRequestDTO> request) {
+  public String sendMessage(List<SendMessageRequestDTO> request) {
 
-		try {
-			Map<String, Object> wrappedRequest = Map.of("messages", request);
+    try {
+      Map<String, Object> wrappedRequest = Map.of("messages", request);
 
-			String response = webClient.post()
-				.uri("/send-many/detail")
-				.bodyValue(wrappedRequest)
-				.retrieve()
-				.bodyToMono(String.class)
-				.block();
+      String response = webClient.post()
+          .uri("/send-many/detail")
+          .bodyValue(wrappedRequest)
+          .retrieve()
+          .bodyToMono(String.class)
+          .block();
 
-			log.info("메시지 전송 성공: {} 개의 메시지", request.size());
-			return response;
+      log.info("메시지 전송 성공: {} 개의 메시지", request.size());
+      return response;
 
-		} catch (Exception e) {
-			throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
-		}
-	}
+    } catch (Exception e) {
+      throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
+    }
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageServiceImpl.java
@@ -88,13 +88,14 @@ public class MessageServiceImpl implements MessageService {
               clientResponse -> clientResponse.bodyToMono(String.class)
                   .handle((errorBody, sink) -> {
                     log.error("Error response from external API: {}", errorBody);
-                    sink.error(new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED));
+                    sink.error(new MessageException(MessageErrorCode.MESSAGE_HISTORY_EXTERNAL_FAILED));
                   })
           )
           .bodyToMono(MessageHistoryResponseDTO.class)
           .block();
     } catch (Exception e) {
-      throw new MessageException(MessageErrorCode.MESSAGE_SEND_FAILED);
+      log.error("Error response from internal API: {}", e.getMessage());
+      throw new MessageException(MessageErrorCode.MESSAGE_HISTORY_INTERNAL_FAILED);
     }
   }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateService.java
@@ -1,6 +1,6 @@
 package com.zipline.service.message;
 
-import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
+import com.zipline.service.message.dto.request.MessageTemplateRequestDTO;
 
 public interface MessageTemplateService {
   void createMessageTemplate(MessageTemplateRequestDTO requestDTO, Long userUid);

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -1,57 +1,54 @@
 package com.zipline.service.message;
 
-import java.time.LocalDateTime;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.zipline.entity.enums.MessageTemplateCategory;
 import com.zipline.entity.message.MessageTemplate;
 import com.zipline.entity.user.User;
-import com.zipline.global.exception.user.errorcode.UserErrorCode;
-import com.zipline.global.exception.message.errorcode.MessageTemplateErrorCode;
 import com.zipline.global.exception.message.MessageTemplateException;
+import com.zipline.global.exception.message.errorcode.MessageTemplateErrorCode;
 import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.repository.message.MessageTemplateRepository;
 import com.zipline.repository.user.UserRepository;
-import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
-
+import com.zipline.service.message.dto.request.MessageTemplateRequestDTO;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MessageTemplateServiceImpl implements MessageTemplateService {
 
-	private final MessageTemplateRepository messageTemplateRepository;
-	private final UserRepository userRepository;
+  private final MessageTemplateRepository messageTemplateRepository;
+  private final UserRepository userRepository;
 
-	@Override
-	@Transactional
-	public void createMessageTemplate(MessageTemplateRequestDTO requestDTO, Long userUid) {
-		if (requestDTO.getCategory().equals(MessageTemplateCategory.BIRTHDAY)
-			|| requestDTO.getCategory().equals(MessageTemplateCategory.EXPIRED_NOTI)) {
-			messageTemplateRepository.findByCategoryAndUserUidAndDeletedAtIsNull(requestDTO.getCategory(),
-				userUid).ifPresent(template -> {
-				throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_CATEGORY);
-			});
+  @Override
+  @Transactional
+  public void createMessageTemplate(MessageTemplateRequestDTO requestDTO, Long userUid) {
+    if (requestDTO.getCategory().equals(MessageTemplateCategory.BIRTHDAY)
+        || requestDTO.getCategory().equals(MessageTemplateCategory.EXPIRED_NOTI)) {
+      messageTemplateRepository.findByCategoryAndUserUidAndDeletedAtIsNull(requestDTO.getCategory(),
+          userUid).ifPresent(template -> {
+        throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_CATEGORY);
+      });
 
-			User user = userRepository.findById(userUid)
-				.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+      User user = userRepository.findById(userUid)
+          .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-			LocalDateTime now = LocalDateTime.now();
+      LocalDateTime now = LocalDateTime.now();
 
-			MessageTemplate messageTemplate = MessageTemplate.builder()
-				.name(requestDTO.getName())
-				.category(requestDTO.getCategory())
-				.content(requestDTO.getContent())
-				.user(user)
-				.createdAt(now)
-				.updatedAt(now)
-				.build();
+      MessageTemplate messageTemplate = MessageTemplate.builder()
+          .name(requestDTO.getName())
+          .category(requestDTO.getCategory())
+          .content(requestDTO.getContent())
+          .user(user)
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
 
-			messageTemplateRepository.save(messageTemplate);
-		}
-	}
+      messageTemplateRepository.save(messageTemplate);
+    }
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
@@ -1,9 +1,6 @@
 package com.zipline.service.message.dto.request;
-import com.zipline.entity.enums.MessageType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
@@ -2,9 +2,11 @@ package com.zipline.service.message.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@Data
+@NoArgsConstructor
 @Builder
 public class MessageHistoryRequestDTO {
 
@@ -23,4 +25,13 @@ public class MessageHistoryRequestDTO {
   @Schema(description = "한 페이지에 불러옥 목록 개수", example = "10")
   private Integer limit;
 
+  @Builder
+  public MessageHistoryRequestDTO(String criteria, String cond, String value,
+      String startKey, Integer limit) {
+    this.criteria = criteria;
+    this.cond = cond;
+    this.value = value;
+    this.startKey = startKey;
+    this.limit = limit;
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
@@ -17,4 +17,10 @@ public class MessageHistoryRequestDTO {
   @Schema(description = "검색 값", example = "2000,SMS")
   private String value;
 
+  @Schema(description = "현재 목록을 불러올 기준이 되는 키", example = "specific group id")
+  private String startKey;
+
+  @Schema(description = "한 페이지에 불러옥 목록 개수", example = "10")
+  private Integer limit;
+
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageHistoryRequestDTO.java
@@ -1,0 +1,23 @@
+package com.zipline.service.message.dto.request;
+import com.zipline.entity.enums.MessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MessageHistoryRequestDTO {
+
+  @Schema(description = "검색 조건 필드명", example = "statusCode,type")
+  private String criteria;
+
+  @Schema(description = "검색 조건 연산자", example = "eq,eq")
+  private String cond;
+
+  @Schema(description = "검색 값", example = "2000,SMS")
+  private String value;
+
+}

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageTemplateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/MessageTemplateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.zipline.service.message.dto.message.request;
+package com.zipline.service.message.dto.request;
 
 import com.zipline.entity.enums.MessageTemplateCategory;
 import com.zipline.entity.message.MessageTemplate;

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/request/SendMessageRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/request/SendMessageRequestDTO.java
@@ -1,4 +1,4 @@
-package com.zipline.service.message.dto.message.request;
+package com.zipline.service.message.dto.request;
 
 import lombok.Getter;
 

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryDetailDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryDetailDTO.java
@@ -1,0 +1,19 @@
+package com.zipline.service.message.dto.response;
+
+import lombok.Getter;
+
+
+@Getter
+public class MessageHistoryDetailDTO {
+  private String groupId;
+  private String from;
+  private String type;
+  private String subject;
+  private String dateCreated;
+  private String dateUpdated;
+  private String statusCode;
+  private String status;
+  private String to;
+  private String text;
+  private String messageId;
+}

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryResponseDTO.java
@@ -1,11 +1,21 @@
 package com.zipline.service.message.dto.response;
 
+import java.util.Collections;
 import java.util.Map;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class MessageHistoryResponseDTO {
   private String startKey;
+  private String nextKey;
   private int limit;
-  private Map<String, MessageHistoryDetailDTO> messageList;
+  private Map<String, MessageHistoryDetailDTO> groupList;
+
+  public static MessageHistoryResponseDTO emptyResponse() {
+    return MessageHistoryResponseDTO.builder()
+        .groupList(Collections.emptyMap())
+        .build();
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/response/MessageHistoryResponseDTO.java
@@ -1,0 +1,11 @@
+package com.zipline.service.message.dto.response;
+
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class MessageHistoryResponseDTO {
+  private String startKey;
+  private int limit;
+  private Map<String, MessageHistoryDetailDTO> messageList;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44

## 📝작업 내용
* 문자 발송 내역 관련 request/response dto 추가
  * response의 경우 리턴 데이터의 뎁스가 있어서 MessageHistoryResponseDTO(parent) - MessageHistoryDetailDTO(child) 형태로 개발했습니다
* 기존 메세지 관련 DTO를 불필요하게 감싸던 message 폴더 제거
* SmsSignatureGenerator 파일을 common/util로 이동
* 문자 내역 관련 service 코드 추가
  *  외부 api에서 보내주는 에러 관리(onStatus) + 우리가 자체적으로 관리하는 에러(catch)
* 문자 내역 관련 controller 코드 추가

### 참고 링크

* [메시지 조회 api 문서](https://developers.solapi.com/references/messages/getMessageList)
* [메시지 상태 코드](https://developers.solapi.com/references/message-status-codes)
* [메시지 조회 상세 필드](https://developers.solapi.com/references/messages/groups/addGroupMessages#body-params)
