### PR TITLE
feat: 고객 상세 조회 수정 - 계약, 매물, 상담 내역 조회

### DIFF
--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
@@ -16,5 +16,7 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
 	@Query("SELECT c FROM Customer c WHERE c.user.uid = :userUID AND c.deletedAt IS NULL ORDER BY c.uid DESC")
 	Page<Customer> findByUserUidAndDeletedAtIsNull(Long userUID, Pageable pageable);
+
+	boolean existsByUidAndUserUidAndDeletedAtIsNull(Long customerUid, Long userUid);
 }
 

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
@@ -13,11 +13,11 @@ import com.zipline.entity.counsel.Counsel;
 import com.zipline.entity.customer.Customer;
 import com.zipline.entity.user.User;
 import com.zipline.global.exception.auth.AuthException;
-import com.zipline.global.exception.customer.CustomerException;
-import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.global.exception.auth.errorcode.AuthErrorCode;
+import com.zipline.global.exception.customer.CustomerException;
 import com.zipline.global.exception.customer.errorcode.CustomerErrorCode;
 import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.repository.agentProperty.AgentPropertyRepository;
@@ -123,6 +123,7 @@ public class CustomerServiceImpl implements CustomerService {
 
 	@Transactional(readOnly = true)
 	public List<CounselListResponseDTO> getCustomerCounsels(Long customerUid, Long userUid) {
+		validateCustomerExistence(customerUid, userUid);
 		List<Counsel> savedCounsels = counselRepository.findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(
 			customerUid, userUid);
 
@@ -132,6 +133,7 @@ public class CustomerServiceImpl implements CustomerService {
 	@Transactional(readOnly = true)
 	public AgentPropertyListResponseDTO getCustomerProperties(Long customerUid, PageRequestDTO pageRequestDTO,
 		Long userUid) {
+		validateCustomerExistence(customerUid, userUid);
 		Page<AgentProperty> savedAgentPropertiesPage = agentPropertyRepository.findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(
 			customerUid, userUid, pageRequestDTO.toPageable());
 
@@ -144,11 +146,18 @@ public class CustomerServiceImpl implements CustomerService {
 
 	@Transactional(readOnly = true)
 	public List<ContractListResponseDTO.ContractListDTO> getCustomerContracts(Long customerUid, Long userUid) {
+		validateCustomerExistence(customerUid, userUid);
 		List<CustomerContract> savedCustomerContract = customerContractRepository.findByCustomerUidAndUserUid(
 			customerUid, userUid);
 		List<ContractListResponseDTO.ContractListDTO> result = savedCustomerContract.stream()
 			.map(cc -> new ContractListResponseDTO.ContractListDTO(cc))
 			.toList();
 		return result;
+	}
+
+	private void validateCustomerExistence(Long customerUid, Long userUid) {
+		if (!customerRepository.existsByUidAndUserUidAndDeletedAtIsNull(customerUid, userUid)) {
+			throw new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND);
+		}
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #204 

## 📝작업 내용
> 고객 상세 조회 시 유효한 고객이 아니면 404를 반환하도록 변경
 - 공인중개사의 UID와 고객의 UID로 exists Query 작성

