### PR TITLE
fix: 문자 템플릿 생성 시 유효성 검사 로직 수정

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/message/errorcode/MessageTemplateErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/message/errorcode/MessageTemplateErrorCode.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 import com.zipline.global.exception.ErrorCode;
 
 public enum MessageTemplateErrorCode implements ErrorCode {
-	DUPLICATE_TEMPLATE_CATEGORY("MSG-TEMPLATE-001", "해당 카테고리의 메시지 템플릿이 이미 존재합니다.", HttpStatus.CONFLICT);
-
+	DUPLICATE_TEMPLATE_CATEGORY("MSG-TEMPLATE-001", "해당 카테고리의 메시지 템플릿이 이미 존재합니다.", HttpStatus.CONFLICT),
+	DUPLICATE_TEMPLATE_NAME("MSG-TEMPLATE-002", "같은 이름의 메시지 템플릿이 이미 존재합니다.", HttpStatus.CONFLICT);
 	private final String code;
 	private final String message;
 	private final HttpStatus status;

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
@@ -1,8 +1,8 @@
 package com.zipline.controller.message;
 
-import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.message.MessageTemplateService;
+import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
 import com.zipline.service.message.dto.message.response.MessageTemplateResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
@@ -36,7 +36,7 @@ public class MessageTemplateController {
   }
 
   @GetMapping("")
-  public ResponseEntity<ApiResponse<List<MessageTemplateResponseDTO>>> getMessageTemplate(Principal principal) {
+  public ResponseEntity<ApiResponse<List<MessageTemplateResponseDTO>>> getMessageTemplateList(Principal principal) {
     List<MessageTemplateResponseDTO> messageTemplateList =messageTemplateService.getMessageTemplateList(Long.parseLong(principal.getName()));
     ApiResponse<List<MessageTemplateResponseDTO>> response = ApiResponse.ok("문자 템플릿 목록 조회 성공", messageTemplateList);
     return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/message/MessageTemplateController.java
@@ -3,11 +3,14 @@ package com.zipline.controller.message;
 import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.message.MessageTemplateService;
+import com.zipline.service.message.dto.message.response.MessageTemplateResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +33,12 @@ public class MessageTemplateController {
     messageTemplateService.createMessageTemplate(request, Long.parseLong(principal.getName()));
     ApiResponse<Void> response = ApiResponse.create("문자 템플릿 등록 성공");
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @GetMapping("")
+  public ResponseEntity<ApiResponse<List<MessageTemplateResponseDTO>>> getMessageTemplate(Principal principal) {
+    List<MessageTemplateResponseDTO> messageTemplateList =messageTemplateService.getMessageTemplateList(Long.parseLong(principal.getName()));
+    ApiResponse<List<MessageTemplateResponseDTO>> response = ApiResponse.ok("문자 템플릿 목록 조회 성공", messageTemplateList);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/apiserver/domain/src/main/java/com/zipline/entity/message/MessageTemplate.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/message/MessageTemplate.java
@@ -1,9 +1,7 @@
 package com.zipline.entity.message;
 
-import com.zipline.entity.customer.Customer;
 import com.zipline.entity.enums.MessageTemplateCategory;
 import com.zipline.entity.user.User;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -14,11 +12,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "message_templates")
 @Entity
+@Getter
 public class MessageTemplate {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageTemplateRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageTemplateRepository.java
@@ -2,9 +2,11 @@ package com.zipline.repository.message;
 
 import com.zipline.entity.enums.MessageTemplateCategory;
 import com.zipline.entity.message.MessageTemplate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageTemplateRepository  extends JpaRepository<MessageTemplate, Long> {
   Optional<MessageTemplate> findByCategoryAndUserUidAndDeletedAtIsNull(MessageTemplateCategory category, Long userUid);
+  List<MessageTemplate> findByUserUid(Long userUid);
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageTemplateRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/message/MessageTemplateRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageTemplateRepository  extends JpaRepository<MessageTemplate, Long> {
   Optional<MessageTemplate> findByCategoryAndUserUidAndDeletedAtIsNull(MessageTemplateCategory category, Long userUid);
+  Optional<MessageTemplate> findByNameAndUserUidAndDeletedAtIsNull(String name, Long userUid);
   List<MessageTemplate> findByUserUid(Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateService.java
@@ -1,8 +1,10 @@
 package com.zipline.service.message;
 
 import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
+import com.zipline.service.message.dto.message.response.MessageTemplateResponseDTO;
+import java.util.List;
 
 public interface MessageTemplateService {
   void createMessageTemplate(MessageTemplateRequestDTO requestDTO, Long userUid);
-
+  List<MessageTemplateResponseDTO> getMessageTemplateList(Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,7 +55,7 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 	}
 
 	@Override
-	@ReadOnlyProperty
+	@Transactional(readOnly = true)
 	public List<MessageTemplateResponseDTO> getMessageTemplateList(Long userUid) {
 		List<MessageTemplate> messageTemplateList = messageTemplateRepository.findByUserUid(userUid);
 		return messageTemplateList.stream()

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -35,6 +35,7 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 				userUid).ifPresent(template -> {
 				throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_CATEGORY);
 			});
+		}
 
 			User user = userRepository.findById(userUid)
 				.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -51,7 +52,7 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 				.build();
 
 			messageTemplateRepository.save(messageTemplate);
-		}
+
 	}
 
 	@Override

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -1,23 +1,23 @@
 package com.zipline.service.message;
 
-import java.time.LocalDateTime;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.zipline.entity.enums.MessageTemplateCategory;
 import com.zipline.entity.message.MessageTemplate;
 import com.zipline.entity.user.User;
-import com.zipline.global.exception.user.errorcode.UserErrorCode;
-import com.zipline.global.exception.message.errorcode.MessageTemplateErrorCode;
 import com.zipline.global.exception.message.MessageTemplateException;
+import com.zipline.global.exception.message.errorcode.MessageTemplateErrorCode;
 import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.repository.message.MessageTemplateRepository;
 import com.zipline.repository.user.UserRepository;
 import com.zipline.service.message.dto.message.request.MessageTemplateRequestDTO;
-
+import com.zipline.service.message.dto.message.response.MessageTemplateResponseDTO;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.annotation.ReadOnlyProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -53,5 +53,15 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 
 			messageTemplateRepository.save(messageTemplate);
 		}
+	}
+
+	@Override
+	@ReadOnlyProperty
+	public List<MessageTemplateResponseDTO> getMessageTemplateList(Long userUid) {
+		List<MessageTemplate> messageTemplateList = messageTemplateRepository.findByUserUid(userUid);
+		return messageTemplateList.stream()
+				.map(
+						MessageTemplateResponseDTO::new)
+				.toList();
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -60,8 +60,7 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 	public List<MessageTemplateResponseDTO> getMessageTemplateList(Long userUid) {
 		List<MessageTemplate> messageTemplateList = messageTemplateRepository.findByUserUid(userUid);
 		return messageTemplateList.stream()
-				.map(
-						MessageTemplateResponseDTO::new)
+				.map(MessageTemplateResponseDTO::new)
 				.toList();
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -29,6 +29,11 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 	@Override
 	@Transactional
 	public void createMessageTemplate(MessageTemplateRequestDTO requestDTO, Long userUid) {
+		messageTemplateRepository.findByNameAndUserUidAndDeletedAtIsNull(requestDTO.getName(), userUid)
+				.ifPresent(template -> {
+					throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_NAME);
+				});
+
 		if (requestDTO.getCategory().equals(MessageTemplateCategory.BIRTHDAY)
 			|| requestDTO.getCategory().equals(MessageTemplateCategory.EXPIRED_NOTI)) {
 			messageTemplateRepository.findByCategoryAndUserUidAndDeletedAtIsNull(requestDTO.getCategory(),

--- a/apiserver/service/src/main/java/com/zipline/service/message/dto/message/response/MessageTemplateResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/dto/message/response/MessageTemplateResponseDTO.java
@@ -1,0 +1,20 @@
+package com.zipline.service.message.dto.message.response;
+
+import com.zipline.entity.enums.MessageTemplateCategory;
+import com.zipline.entity.message.MessageTemplate;
+import lombok.Getter;
+
+@Getter
+public class MessageTemplateResponseDTO {
+  private Long uid;
+  private String name;
+  private MessageTemplateCategory category;
+  private String content;
+
+  public MessageTemplateResponseDTO(MessageTemplate messageTemplate) {
+    this.uid = messageTemplate.getUid();
+    this.name = messageTemplate.getName();
+    this.category = messageTemplate.getCategory();
+    this.content = messageTemplate.getContent();
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #226

## 📝작업 내용
* 문자 템플릿 생성 시 같은 이름의 템플릿이 존재하는지 검사하는 코드 추가
* 문자 템플릿의 카테고리가`GENERAL`일 때 생성 안되는 버그 수정 (-> 중괄호 수정) 
