### PR TITLE
refactor: Customer

### DIFF
--- a/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
@@ -44,8 +44,9 @@ public class CustomerController {
 	@GetMapping("/customers")
 	public ResponseEntity<ApiResponse<CustomerListResponseDTO>> getCustomers(PageRequestDTO pageRequestDTO,
 		Principal principal) {
-		ApiResponse<CustomerListResponseDTO> response = customerService.getCustomers(pageRequestDTO,
+		CustomerListResponseDTO result = customerService.getCustomers(pageRequestDTO,
 			Long.parseLong(principal.getName()));
+		ApiResponse<CustomerListResponseDTO> response = ApiResponse.ok("고객 목록 조회에 성공하였습니다.", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
@@ -72,8 +73,8 @@ public class CustomerController {
 	public ResponseEntity<ApiResponse<Void>> registerCustomer(
 		@Valid @RequestBody CustomerRegisterRequestDTO customerRegisterRequestDTO, Principal principal) {
 
-		ApiResponse<Void> response = customerService.registerCustomer(customerRegisterRequestDTO,
-			Long.parseLong(principal.getName()));
+		customerService.registerCustomer(customerRegisterRequestDTO, Long.parseLong(principal.getName()));
+		ApiResponse<Void> response = ApiResponse.create("고객 등록에 성공하였습니다.");
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
@@ -99,15 +100,16 @@ public class CustomerController {
 	public ResponseEntity<ApiResponse<CustomerDetailResponseDTO>> modifyCustomer(@PathVariable Long customerUid,
 		@Valid @RequestBody CustomerModifyRequestDTO customerModifyRequestDTO, Principal principal) {
 
-		ApiResponse<CustomerDetailResponseDTO> response = customerService.modifyCustomer(
+		CustomerDetailResponseDTO result = customerService.modifyCustomer(
 			customerUid, customerModifyRequestDTO, Long.parseLong(principal.getName()));
+		ApiResponse<CustomerDetailResponseDTO> response = ApiResponse.ok("고객 수정에 성공하였습니다.", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 	@DeleteMapping("/customers/{customerUid}")
 	public ResponseEntity<ApiResponse<Void>> deleteCustomer(@PathVariable Long customerUid, Principal principal) {
-		ApiResponse<Void> response = customerService.deleteCustomer(customerUid,
-			Long.parseLong(principal.getName()));
+		customerService.deleteCustomer(customerUid, Long.parseLong(principal.getName()));
+		ApiResponse<Void> response = ApiResponse.ok("고객 삭제에 성공하였습니다.");
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/v1/")
 @RestController
 public class CustomerController {
 

--- a/apiserver/domain/src/main/java/com/zipline/entity/label/LabelCustomer.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/label/LabelCustomer.java
@@ -35,8 +35,4 @@ public class LabelCustomer {
 		this.customer = customer;
 		this.label = label;
 	}
-
-	public static LabelCustomer create(Customer customer, Label label) {
-		return new LabelCustomer(customer, label);
-	}
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/label/LabelRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/label/LabelRepository.java
@@ -13,4 +13,6 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
 	Optional<Label> findByUidAndUserUidAndDeletedAtIsNull(Long labelUid, Long userUid);
 
 	List<Label> findAllByUserUidAndDeletedAtIsNull(Long userUid);
+
+	List<Label> findAllByUidInAndUserUidAndDeletedAtIsNull(List<Long> labelUids, Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
@@ -3,7 +3,6 @@ package com.zipline.service.customer;
 import java.util.List;
 
 import com.zipline.global.request.PageRequestDTO;
-import com.zipline.global.response.ApiResponse;
 import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseDTO;
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
 import com.zipline.service.counsel.dto.response.CounselListResponseDTO;
@@ -14,15 +13,14 @@ import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
 
 public interface CustomerService {
 
-	ApiResponse<Void> registerCustomer(CustomerRegisterRequestDTO customerRegisterRequestDTO, Long userUID);
+	void registerCustomer(CustomerRegisterRequestDTO customerRegisterRequestDTO, Long userUid);
 
-	ApiResponse<CustomerDetailResponseDTO> modifyCustomer(Long customerUid,
-		CustomerModifyRequestDTO customerModifyRequestDTO,
-		Long userUID);
+	CustomerDetailResponseDTO modifyCustomer(Long customerUid, CustomerModifyRequestDTO customerModifyRequestDTO,
+		Long userUid);
 
-	ApiResponse<Void> deleteCustomer(Long customerUID, Long userUID);
+	void deleteCustomer(Long customerUID, Long userUid);
 
-	ApiResponse<CustomerListResponseDTO> getCustomers(PageRequestDTO pageRequestDTO, Long userUID);
+	CustomerListResponseDTO getCustomers(PageRequestDTO pageRequestDTO, Long userUid);
 
 	CustomerDetailResponseDTO getCustomer(Long customerUid, Long userUid);
 

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
@@ -62,15 +62,16 @@ public class CustomerServiceImpl implements CustomerService {
 		Customer customer = customerRegisterRequestDTO.toEntity(loginedUser);
 		customerRepository.save(customer);
 
-		List<Long> labelUids = customerRegisterRequestDTO.getLabelUids();
-		if (labelUids != null && !labelUids.isEmpty()) {
-			List<Label> labels = labelRepository.findAllByUidInAndUserUidAndDeletedAtIsNull(labelUids, userUid);
+		List<Long> requestLabelUids = customerRegisterRequestDTO.getLabelUids();
+		if (requestLabelUids != null && !requestLabelUids.isEmpty()) {
+			List<Label> validLabels = labelRepository.findAllByUidInAndUserUidAndDeletedAtIsNull(requestLabelUids,
+				userUid);
 
-			if (labels.size() != labelUids.size()) {
+			if (validLabels.size() != requestLabelUids.size()) {
 				throw new LabelException(LabelErrorCode.LABEL_NOT_FOUND);
 			}
 
-			List<LabelCustomer> labelCustomers = labels.stream()
+			List<LabelCustomer> labelCustomers = validLabels.stream()
 				.map(label -> new LabelCustomer(customer, label))
 				.toList();
 

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
@@ -1,11 +1,7 @@
 package com.zipline.service.customer;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -18,8 +14,6 @@ import com.zipline.entity.customer.Customer;
 import com.zipline.entity.label.Label;
 import com.zipline.entity.label.LabelCustomer;
 import com.zipline.entity.user.User;
-import com.zipline.global.exception.auth.AuthException;
-import com.zipline.global.exception.auth.errorcode.AuthErrorCode;
 import com.zipline.global.exception.customer.CustomerException;
 import com.zipline.global.exception.customer.errorcode.CustomerErrorCode;
 import com.zipline.global.exception.label.LabelException;
@@ -27,7 +21,6 @@ import com.zipline.global.exception.label.errorcode.LabelErrorCode;
 import com.zipline.global.exception.user.UserException;
 import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.global.request.PageRequestDTO;
-import com.zipline.global.response.ApiResponse;
 import com.zipline.repository.agentProperty.AgentPropertyRepository;
 import com.zipline.repository.contract.CustomerContractRepository;
 import com.zipline.repository.counsel.CounselRepository;
@@ -60,78 +53,34 @@ public class CustomerServiceImpl implements CustomerService {
 	private final LabelCustomerRepository labelCustomerRepository;
 
 	@Transactional
-	public ApiResponse<Void> registerCustomer(CustomerRegisterRequestDTO customerRegisterRequestDTO, Long userUID) {
-		User loginedUser = userRepository.findById(userUID)
+	public void registerCustomer(CustomerRegisterRequestDTO customerRegisterRequestDTO, Long userUid) {
+		User loginedUser = userRepository.findById(userUid)
 			.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 		Customer customer = customerRegisterRequestDTO.toEntity(loginedUser);
 		customerRepository.save(customer);
+
 		List<Long> labelUids = customerRegisterRequestDTO.getLabelUids();
-
 		if (labelUids != null && !labelUids.isEmpty()) {
-			List<LabelCustomer> labelCustomers = new ArrayList<>();
+			List<Label> labels = labelRepository.findAllByUidInAndUserUidAndDeletedAtIsNull(labelUids, userUid);
 
-			for (Long labelUid : labelUids) {
-				Label label = labelRepository.findById(labelUid)
-					.orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
-
-				if (!label.getUser().getUid().equals(userUID)) {
-					throw new LabelException(LabelErrorCode.LABEL_NOT_FOUND);
-				}
-
-				labelCustomers.add(new LabelCustomer(customer, label));
+			if (labels.size() != labelUids.size()) {
+				throw new LabelException(LabelErrorCode.LABEL_NOT_FOUND);
 			}
+
+			List<LabelCustomer> labelCustomers = labels.stream()
+				.map(label -> new LabelCustomer(customer, label))
+				.toList();
 
 			labelCustomerRepository.saveAll(labelCustomers);
 		}
-
-		return ApiResponse.create("고객 등록에 성공하였습니다.");
 	}
 
 	@Transactional
-	public ApiResponse<CustomerDetailResponseDTO> modifyCustomer(Long customerUid,
-		CustomerModifyRequestDTO customerModifyRequestDTO, Long userUID) {
+	public CustomerDetailResponseDTO modifyCustomer(Long customerUid,
+		CustomerModifyRequestDTO customerModifyRequestDTO, Long userUid) {
 
 		Customer savedCustomer = customerRepository.findByUidAndDeletedAtIsNull(customerUid)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-
-		if (!savedCustomer.getUser().getUid().equals(userUID)) {
-			throw new AuthException(AuthErrorCode.PERMISSION_DENIED);
-		}
-		List<Long> labelUids = customerModifyRequestDTO.getLabelUids();
-
-		if (labelUids != null) {
-			// 기존 라벨 매핑 가져오기
-			List<LabelCustomer> existingMappings = labelCustomerRepository.findAllByCustomerUid(savedCustomer.getUid());
-
-			// 수정 요청한 labelUid Set 만들기
-			Set<Long> requestedLabelUids = new HashSet<>(labelUids);
-
-			// 1. 기존 매핑 중 요청에 없는 것은 삭제
-			List<LabelCustomer> toDelete = existingMappings.stream()
-				.filter(mapping -> !requestedLabelUids.contains(mapping.getLabel().getUid()))
-				.toList();
-			labelCustomerRepository.deleteAll(toDelete);
-
-			// 2. 요청한 labelUid 중 아직 매핑되지 않은 것은 추가
-			Set<Long> existingLabelUids = existingMappings.stream()
-				.map(mapping -> mapping.getLabel().getUid())
-				.collect(Collectors.toSet());
-
-			List<LabelCustomer> toAdd = new ArrayList<>();
-			for (Long labelUid : labelUids) {
-				if (!existingLabelUids.contains(labelUid)) {
-					Label label = labelRepository.findById(labelUid)
-						.orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
-
-					if (!label.getUser().getUid().equals(userUID)) {
-						throw new LabelException(LabelErrorCode.LABEL_NOT_FOUND);
-					}
-
-					toAdd.add(new LabelCustomer(savedCustomer, label));
-				}
-			}
-			labelCustomerRepository.saveAll(toAdd);
-		}
 
 		savedCustomer.modifyCustomer(customerModifyRequestDTO.getName(), customerModifyRequestDTO.getPhoneNo(),
 			customerModifyRequestDTO.getTelProvider(),
@@ -145,48 +94,33 @@ public class CustomerServiceImpl implements CustomerService {
 			customerModifyRequestDTO.getMinDeposit(), customerModifyRequestDTO.getMaxDeposit(),
 			customerModifyRequestDTO.getBirthday());
 
-		List<LabelCustomer> updatedLabelMappings = labelCustomerRepository.findAllByCustomerUid(savedCustomer.getUid());
-		CustomerDetailResponseDTO customerDetailResponseDTO = new CustomerDetailResponseDTO(savedCustomer,
-			updatedLabelMappings);
-		return ApiResponse.ok("고객 수정에 성공하였습니다.", customerDetailResponseDTO);
+		return new CustomerDetailResponseDTO(savedCustomer);
 	}
 
 	@Transactional
-	public ApiResponse<Void> deleteCustomer(Long customerUID, Long userUID) {
+	public void deleteCustomer(Long customerUID, Long userUid) {
 		Customer savedCustomer = customerRepository.findByUidAndDeletedAtIsNull(customerUID)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-
-		if (!savedCustomer.getUser().getUid().equals(userUID)) {
-			throw new AuthException(AuthErrorCode.PERMISSION_DENIED);
-		}
-
-		savedCustomer.delete(LocalDateTime.now());
-		return ApiResponse.ok("고객 삭제에 성공하였습니다.");
+		LocalDateTime deletedAt = LocalDateTime.now();
+		savedCustomer.delete(deletedAt);
 	}
 
 	@Transactional(readOnly = true)
-	public ApiResponse<CustomerListResponseDTO> getCustomers(PageRequestDTO pageRequestDTO, Long userUID) {
-		Page<Customer> customerPage = customerRepository.findByUserUidAndDeletedAtIsNull(userUID,
+	public CustomerListResponseDTO getCustomers(PageRequestDTO pageRequestDTO, Long userUid) {
+		Page<Customer> customerPage = customerRepository.findByUserUidAndDeletedAtIsNull(userUid,
 			pageRequestDTO.toPageable());
 		List<CustomerListResponseDTO.CustomerResponseDTO> customerResponseDTOList = customerPage.getContent().stream()
 			.map(CustomerListResponseDTO.CustomerResponseDTO::new)
 			.toList();
 
-		CustomerListResponseDTO result = new CustomerListResponseDTO(customerResponseDTOList, customerPage);
-
-		return ApiResponse.ok("고객 목록 조회에 성공하였습니다.", result);
+		return new CustomerListResponseDTO(customerResponseDTOList, customerPage);
 	}
 
 	@Transactional(readOnly = true)
 	public CustomerDetailResponseDTO getCustomer(Long customerUid, Long userUid) {
 		Customer savedCustomer = customerRepository.findByUidAndDeletedAtIsNull(customerUid)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-
-		if (!savedCustomer.getUser().getUid().equals(userUid)) {
-			throw new AuthException(AuthErrorCode.PERMISSION_DENIED);
-		}
-
-		return new CustomerDetailResponseDTO(savedCustomer, null);
+		return new CustomerDetailResponseDTO(savedCustomer);
 	}
 
 	@Transactional(readOnly = true)
@@ -194,7 +128,6 @@ public class CustomerServiceImpl implements CustomerService {
 		validateCustomerExistence(customerUid, userUid);
 		List<Counsel> savedCounsels = counselRepository.findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(
 			customerUid, userUid);
-
 		return savedCounsels.stream().map(CounselListResponseDTO::createWithoutCustomerName).toList();
 	}
 
@@ -217,10 +150,9 @@ public class CustomerServiceImpl implements CustomerService {
 		validateCustomerExistence(customerUid, userUid);
 		List<CustomerContract> savedCustomerContract = customerContractRepository.findByCustomerUidAndUserUid(
 			customerUid, userUid);
-		List<ContractListResponseDTO.ContractListDTO> result = savedCustomerContract.stream()
-			.map(cc -> new ContractListResponseDTO.ContractListDTO(cc))
+		return savedCustomerContract.stream()
+			.map(ContractListResponseDTO.ContractListDTO::new)
 			.toList();
-		return result;
 	}
 
 	private void validateCustomerExistence(Long customerUid, Long userUid) {

--- a/apiserver/service/src/main/java/com/zipline/service/customer/dto/request/CustomerModifyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/dto/request/CustomerModifyRequestDTO.java
@@ -10,7 +10,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class CustomerModifyRequestDTO {
@@ -43,16 +45,16 @@ public class CustomerModifyRequestDTO {
 	private String trafficSource;
 
 	@Schema(description = "임대인 여부", example = "true")
-	private boolean isLandlord;
+	private boolean landlord;
 
 	@Schema(description = "임차인 여부", example = "true")
-	private boolean isTenant;
+	private boolean tenant;
 
 	@Schema(description = "매수인 여부", example = "false")
-	private boolean isBuyer;
+	private boolean buyer;
 
 	@Schema(description = "매도인 여부", example = "false")
-	private boolean isSeller;
+	private boolean seller;
 
 	@Schema(description = "최대 가격", example = "100000000")
 	@DecimalMin(value = "0", message = "최대 가격은 0 이상이어야 합니다.")

--- a/apiserver/service/src/main/java/com/zipline/service/customer/dto/request/CustomerRegisterRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/dto/request/CustomerRegisterRequestDTO.java
@@ -13,7 +13,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class CustomerRegisterRequestDTO {
@@ -47,16 +49,16 @@ public class CustomerRegisterRequestDTO {
 	private String trafficSource;
 
 	@Schema(description = "임대인 여부", example = "true")
-	private boolean isLandlord;
+	private boolean landlord;
 
 	@Schema(description = "임차인 여부", example = "true")
-	private boolean isTenant;
+	private boolean tenant;
 
 	@Schema(description = "매수인 여부", example = "false")
-	private boolean isBuyer;
+	private boolean buyer;
 
 	@Schema(description = "매도인 여부", example = "false")
-	private boolean isSeller;
+	private boolean seller;
 
 	@Schema(description = "최대 가격", example = "100000000")
 	@DecimalMin(value = "0", message = "최대 가격은 0 이상이어야 합니다.")
@@ -87,10 +89,10 @@ public class CustomerRegisterRequestDTO {
 			.minRent(minRent)
 			.maxRent(maxRent)
 			.trafficSource(trafficSource)
-			.isLandlord(isLandlord)
-			.isTenant(isTenant)
-			.isBuyer(isBuyer)
-			.isSeller(isSeller)
+			.isLandlord(landlord)
+			.isTenant(tenant)
+			.isBuyer(buyer)
+			.isSeller(seller)
 			.maxPrice(maxPrice)
 			.minPrice(minPrice)
 			.minDeposit(minDeposit)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #229 

## 📝작업 내용
> Customer 관련 Api Endpoint에 버전 정보 추가

> Service에서 ApiResponse로 감싸진 DTO가 아닌 data 관련 DTO만 반환하도록 변경]

> Permission 검증 로직 삭제
- DB에서 UserUid로 필터링해서 조회하므로 검증 로직이 필요 없음

> Customer 생성 시 Label 매핑 로직 리팩토링
- 기존: 입력된 Label의 Uid의 개수마다 Label을 조회한 후, User의 라벨인지 검사하는 로직
- 변경: 입력된 Label의 Uids와 User의 Uid로 한번 조회 후, 개수 비교하는 방식으로 최적화