### PR TITLE
feat: 일정 생성 api 추가

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/schedule/ScheduleException.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/schedule/ScheduleException.java
@@ -1,0 +1,10 @@
+package com.zipline.global.exception.schedule;
+
+import com.zipline.global.exception.BaseException;
+import com.zipline.global.exception.schedule.errorcode.ScheduleErrorCode;
+
+public class ScheduleException extends BaseException {
+	public ScheduleException(ScheduleErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/exception/schedule/errorcode/ScheduleErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/schedule/errorcode/ScheduleErrorCode.java
@@ -1,0 +1,32 @@
+package com.zipline.global.exception.schedule.errorcode;
+
+import com.zipline.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ScheduleErrorCode implements ErrorCode {
+	INVALID_SCHEDULE_TIME("MSG-001", "시작 시간이 종료 시간보다 늦을 수 없습니다.", HttpStatus.BAD_REQUEST);
+	private final String code;
+	private final String message;
+	private final HttpStatus status;
+
+	ScheduleErrorCode(String code, String message, HttpStatus status) {
+		this.code = code;
+		this.message = message;
+		this.status = status;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
@@ -4,6 +4,7 @@ import com.zipline.global.response.ApiResponse;
 import com.zipline.service.schedule.ScheduleService;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,7 +23,7 @@ public class ScheduleController {
   }
 
   @PostMapping("")
-  public ResponseEntity<ApiResponse<Void>> createSchedule(@RequestBody ScheduleCreateRequestDTO request,
+  public ResponseEntity<ApiResponse<Void>> createSchedule(@RequestBody @Valid ScheduleCreateRequestDTO request,
       Principal principal) {
     scheduleService.createSchedule(request, Long.parseLong(principal.getName()));
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
@@ -1,0 +1,33 @@
+package com.zipline.controller.schedule;
+
+import com.zipline.global.response.ApiResponse;
+import com.zipline.service.schedule.ScheduleService;
+import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/schedules")
+@Tag(name = "일정", description = "일정 관련 api")
+@RestController
+public class ScheduleController {
+  private final ScheduleService scheduleService;
+
+  public ScheduleController(ScheduleService scheduleService) {
+    this.scheduleService = scheduleService;
+  }
+
+  @PostMapping("")
+  public ResponseEntity<ApiResponse<Void>> createSchedule(@RequestBody ScheduleCreateRequestDTO request,
+      Principal principal) {
+    scheduleService.createSchedule(request, Long.parseLong(principal.getName()));
+
+    ApiResponse<Void> responseBody = ApiResponse.ok("일정 생성 성공");
+    return ResponseEntity.ok(responseBody);
+  }
+
+}

--- a/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
@@ -1,0 +1,60 @@
+package com.zipline.entity.schedule;
+
+import com.zipline.entity.BaseTimeEntity;
+import com.zipline.entity.customer.Customer;
+import com.zipline.entity.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "schedules")
+@Entity
+public class Schedule extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "uid", nullable = false)
+  private Long uid;
+
+  @Column(length = 20, nullable = false)
+  private String title;
+
+  @Column(length = 200)
+  private String description;
+
+  @Column(name = "start_date", nullable = false)
+  private LocalDateTime startDate;
+
+  @Column(name = "end_date", nullable = false)
+  private LocalDateTime endDate;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "customer_uid", nullable = false)
+  private Customer customer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_uid", nullable = false)
+  private User user;
+
+  @Builder
+  public Schedule(String title, String description, LocalDateTime startDate, LocalDateTime endDate, Customer customer, User user) {
+    this.title = title;
+    this.description = description;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.customer = customer;
+    this.user = user;
+  }
+}

--- a/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
@@ -41,7 +41,7 @@ public class Schedule extends BaseTimeEntity {
   private LocalDateTime endDate;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "customer_uid", nullable = false)
+  @JoinColumn(name = "customer_uid")
   private Customer customer;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/schedule/ScheduleRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/schedule/ScheduleRepository.java
@@ -1,0 +1,9 @@
+package com.zipline.repository.schedule;
+
+
+import com.zipline.entity.schedule.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+}

--- a/apiserver/service/build.gradle
+++ b/apiserver/service/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 bootJar {

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
@@ -1,0 +1,8 @@
+package com.zipline.service.schedule;
+
+import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+
+public interface ScheduleService {
+  void createSchedule(ScheduleCreateRequestDTO request, Long userUid);
+
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -1,0 +1,46 @@
+package com.zipline.service.schedule;
+
+import com.zipline.entity.customer.Customer;
+import com.zipline.entity.schedule.Schedule;
+import com.zipline.entity.user.User;
+import com.zipline.global.exception.customer.CustomerException;
+import com.zipline.global.exception.customer.errorcode.CustomerErrorCode;
+import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
+import com.zipline.repository.customer.CustomerRepository;
+import com.zipline.repository.schedule.ScheduleRepository;
+import com.zipline.repository.user.UserRepository;
+import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceImpl implements ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+    private final CustomerRepository customerRepository;
+
+    @Override
+    @Transactional
+    public void createSchedule(ScheduleCreateRequestDTO request, Long userUid) {
+        User user = userRepository.findById(userUid)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Customer customer = customerRepository.findById(request.getCustomerId().longValue())
+            .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+
+        Schedule schedule = Schedule.builder()
+            .title(request.getTitle())
+            .description(request.getDescription())
+            .startDate(request.getStartDateTime())
+            .endDate(request.getEndDateTime())
+            .user(user)
+            .customer(customer)
+            .build();
+
+        scheduleRepository.save(schedule);
+    }
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -29,8 +29,6 @@ public class ScheduleServiceImpl implements ScheduleService {
         User user = userRepository.findById(userUid)
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        Customer customer = customerRepository.findById(request.getCustomerId().longValue())
-            .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
         Schedule schedule = Schedule.builder()
             .title(request.getTitle())

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
@@ -1,0 +1,31 @@
+package com.zipline.service.schedule.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScheduleCreateRequestDTO {
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime startDateTime;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime endDateTime;
+
+  private String title;
+  private String description;
+  private Integer customerId;
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,14 +20,21 @@ public class ScheduleCreateRequestDTO {
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   @JsonDeserialize(using = LocalDateTimeDeserializer.class)
   @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @NotNull(message = "시작 시간은 필수 입력값입니다.")
   private LocalDateTime startDateTime;
 
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   @JsonDeserialize(using = LocalDateTimeDeserializer.class)
   @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @NotNull(message = "종료 시간은 필수 입력값입니다.")
   private LocalDateTime endDateTime;
 
+  @Size(min = 2, max = 15, message = "일정 제목은 2자 이상 15자 이하로 입력해주세요.")
+  @NotNull(message = "제목은 필수 입력값입니다.")
   private String title;
+
+  @Size(min = 2, max = 200, message = "일정 설명은 2자 이상 200자 이하로 입력해주세요.")
   private String description;
+
   private Integer customerId;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #240

## 📝작업 내용
* 일정 생성 api 추가
* 일정 validation
  * 일정 제목 길이 및 입력 여부
  * 일정 설명 길이 및 입력 여부
  * 시작시간 < 종료시간 및 입력 여부
* 그 외
  1. 시간 형식은 JavaScript의 `new Date()` 를 써서 별도의 포맷팅 없이 보내주려고 로 처리했습니다! ("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", ISO 8601 형식) 더 좋은 방법이 있다면 알려주세요 ☺️
  2. LocalDateTime 처리를 위한 디펜던시 추가
  ```
  com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.LocalDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling at ...
  ``` 