### PR TITLE
feat: 일정 조회 api 추가

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/config/JacksonConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/JacksonConfig.java
@@ -1,23 +1,44 @@
 package com.zipline.global.config;
 
-import org.springframework.context.annotation.Configuration;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
-public class JacksonConfig {
+public class JacksonConfig implements WebMvcConfigurer {
+	private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+
 
 	private final ObjectMapper objectMapper;
 
 	@PostConstruct
 	public void setUp() {
-		objectMapper.registerModule(new JavaTimeModule());
+		JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+		javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DATE_TIME_FORMATTER));
+		javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DATE_TIME_FORMATTER));
+
+		objectMapper.registerModule(javaTimeModule);
 		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
+	@Override
+	public void addFormatters(@NonNull FormatterRegistry registry) {
+		DateTimeFormatterRegistrar registrar = new DateTimeFormatterRegistrar();
+		registrar.setDateTimeFormatter(DATE_TIME_FORMATTER);
+		registrar.registerFormatters(registry);
 	}
 }

--- a/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
@@ -2,12 +2,17 @@ package com.zipline.controller.schedule;
 
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.schedule.ScheduleService;
+import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +38,20 @@ public class ScheduleController {
     ApiResponse<Void> responseBody = ApiResponse.ok("일정 생성 성공");
     return ResponseEntity.ok(responseBody);
   }
+
+  @GetMapping("")
+  public ResponseEntity<ApiResponse<List<ScheduleResponseDTO>>> getScheduleList(
+      @Valid @ModelAttribute DateRangeRequest dateRange,
+      Principal principal) {
+
+    List<ScheduleResponseDTO> scheduleList = scheduleService.getScheduleList(dateRange,
+        Long.parseLong(principal.getName())
+    );
+
+    ApiResponse<List<ScheduleResponseDTO>> response = ApiResponse.ok("일정 목록 조회 성공", scheduleList);
+    return ResponseEntity.ok(response);
+  }
+
 
   @DeleteMapping("/{scheduleUid}")
   public ResponseEntity<ApiResponse<Void>> deleteSchedule(@PathVariable Long scheduleUid,

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/schedule/ScheduleRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/schedule/ScheduleRepository.java
@@ -2,10 +2,25 @@ package com.zipline.repository.schedule;
 
 
 import com.zipline.entity.schedule.Schedule;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
   Optional<Schedule> findByUidAndUserUidAndDeletedAtIsNull(Long scheduleUid, Long userUid);
+  @Query("SELECT s FROM Schedule s " +
+      "LEFT JOIN FETCH s.user u " +
+      "WHERE s.user.uid = :userUid " +
+      "AND s.deletedAt IS NULL " +
+      "AND s.startDate <= :endDate " +
+      "AND s.endDate >= :startDate")
+  List<Schedule> findSchedulesInDateRange(
+      @Param("userUid") Long userUid,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate
+  );
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
@@ -1,10 +1,13 @@
 package com.zipline.service.schedule;
 
+import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
+import java.util.List;
 
 public interface ScheduleService {
 
   void createSchedule(ScheduleCreateRequestDTO request, Long userUid);
-
+  List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid);
   void deleteSchedule(Long scheduleUid, Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -17,6 +17,7 @@ import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
 import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -70,7 +71,10 @@ public class ScheduleServiceImpl implements ScheduleService {
     public List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid) {
         validateScheduleTimeRequest(request.getStartDate(), request.getEndDate());
 
-        return scheduleRepository.findSchedulesInDateRange(userUid, request.getStartDate(), request.getEndDate())
+        LocalDateTime startOfDay = request.getStartDate().toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = request.getEndDate().toLocalDate().atTime(LocalTime.MAX);
+
+        return scheduleRepository.findSchedulesInDateRange(userUid, startOfDay, endOfDay)
             .stream()
             .map(ScheduleResponseDTO::from)
             .toList();

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -18,7 +18,6 @@ import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -66,17 +65,19 @@ public class ScheduleServiceImpl implements ScheduleService {
             throw new ScheduleException(ScheduleErrorCode.INVALID_SCHEDULE_TIME);
         }
     }
-    public List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid) {
-        List<Schedule> scheduleList = scheduleRepository.findSchedulesInDateRange(
-                userUid, request.getStartDate(), request.getEndDate());
-        return scheduleList.stream()
-        validateScheduleTimeRequest(request.getStartDate(), request.getEndDate());
-            .map(ScheduleResponseDTO::from)
-            .collect(Collectors.toList());
-    }
 
-  @Transactional
-  public void deleteSchedule(Long scheduleUid, Long userUid) {
+    @Override
+    public List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid) {
+        validateScheduleTimeRequest(request.getStartDate(), request.getEndDate());
+
+        return scheduleRepository.findSchedulesInDateRange(userUid, request.getStartDate(), request.getEndDate())
+            .stream()
+            .map(ScheduleResponseDTO::from)
+            .toList();
+    }
+    @Override
+    @Transactional
+    public void deleteSchedule(Long scheduleUid, Long userUid) {
     Schedule schedule = scheduleRepository.findByUidAndUserUidAndDeletedAtIsNull(
             scheduleUid, userUid)
         .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -33,7 +33,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     @Transactional
     public void createSchedule(ScheduleCreateRequestDTO request, Long userUid) {
-        validateScheduleTimeRequest(request);
+        validateScheduleTimeRequest(request.getStartDateTime(), request.getEndDateTime());
 
         User user = userRepository.findById(userUid)
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -61,15 +61,16 @@ public class ScheduleServiceImpl implements ScheduleService {
             .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
     }
 
-    private void validateScheduleTimeRequest(ScheduleCreateRequestDTO request) {
-        if (request.getStartDateTime().isAfter(request.getEndDateTime())) {
-            throw  new ScheduleException(ScheduleErrorCode.INVALID_SCHEDULE_TIME);
+    private void validateScheduleTimeRequest(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new ScheduleException(ScheduleErrorCode.INVALID_SCHEDULE_TIME);
         }
     }
     public List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid) {
         List<Schedule> scheduleList = scheduleRepository.findSchedulesInDateRange(
                 userUid, request.getStartDate(), request.getEndDate());
         return scheduleList.stream()
+        validateScheduleTimeRequest(request.getStartDate(), request.getEndDate());
             .map(ScheduleResponseDTO::from)
             .collect(Collectors.toList());
     }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -12,9 +12,13 @@ import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.repository.customer.CustomerRepository;
 import com.zipline.repository.schedule.ScheduleRepository;
 import com.zipline.repository.user.UserRepository;
+import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -62,6 +66,14 @@ public class ScheduleServiceImpl implements ScheduleService {
             throw  new ScheduleException(ScheduleErrorCode.INVALID_SCHEDULE_TIME);
         }
     }
+    public List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid) {
+        List<Schedule> scheduleList = scheduleRepository.findSchedulesInDateRange(
+                userUid, request.getStartDate(), request.getEndDate());
+        return scheduleList.stream()
+            .map(ScheduleResponseDTO::from)
+            .collect(Collectors.toList());
+    }
+
   @Transactional
   public void deleteSchedule(Long scheduleUid, Long userUid) {
     Schedule schedule = scheduleRepository.findByUidAndUserUidAndDeletedAtIsNull(

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/DateRangeRequest.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/DateRangeRequest.java
@@ -4,16 +4,13 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @AllArgsConstructor
 public class DateRangeRequest {
-  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   @NotNull(message = "시작 날짜는 필수입니다.")
   private LocalDateTime startDate;
 
-  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   @NotNull(message = "종료 날짜는 필수입니다.")
   private LocalDateTime endDate;
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/DateRangeRequest.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/DateRangeRequest.java
@@ -1,0 +1,19 @@
+package com.zipline.service.schedule.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@AllArgsConstructor
+public class DateRangeRequest {
+  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @NotNull(message = "시작 날짜는 필수입니다.")
+  private LocalDateTime startDate;
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @NotNull(message = "종료 날짜는 필수입니다.")
+  private LocalDateTime endDate;
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/response/ScheduleResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/response/ScheduleResponseDTO.java
@@ -1,0 +1,62 @@
+package com.zipline.service.schedule.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.zipline.entity.customer.Customer;
+import com.zipline.entity.schedule.Schedule;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+public class ScheduleResponseDTO {
+  private Long uid;
+  private String title;
+  private String description;
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime startDate;
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime endDate;
+
+  private Long customerUid;
+  private String customerName;
+
+  @Builder
+  private ScheduleResponseDTO(Long uid, String title, String description,
+      LocalDateTime startDate, LocalDateTime endDate,
+      Customer customer) {
+    this.uid = uid;
+    this.title = title;
+    this.description = description;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.customerUid = Optional.ofNullable(customer)
+        .map(Customer::getUid)
+        .orElse(null);
+    this.customerName = Optional.ofNullable(customer)
+        .map(Customer::getName)
+        .orElse(null);
+
+  }
+
+  public static ScheduleResponseDTO from(Schedule schedule) {
+    return new ScheduleResponseDTO(
+        schedule.getUid(),
+        schedule.getTitle(),
+        schedule.getDescription(),
+        schedule.getStartDate(),
+        schedule.getEndDate(),
+        schedule.getCustomer()
+    );
+  }
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/response/ScheduleResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/response/ScheduleResponseDTO.java
@@ -1,31 +1,18 @@
 package com.zipline.service.schedule.dto.response;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.zipline.entity.customer.Customer;
 import com.zipline.entity.schedule.Schedule;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 public class ScheduleResponseDTO {
   private Long uid;
   private String title;
   private String description;
-
-  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-  @JsonSerialize(using = LocalDateTimeSerializer.class)
   private LocalDateTime startDate;
-
-  @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-  @JsonSerialize(using = LocalDateTimeSerializer.class)
   private LocalDateTime endDate;
 
   private Long customerUid;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #251

## 📝작업 내용
* LocalDateTime 관련 중복 어노테이션 제거를 위한 JacksonConfig 수정
  ```
  // 중복 어노테이션
   @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
  @JsonSerialize(using = LocalDateTimeSerializer.class)
  ```  

* 일정 조회 api 추가
* 흐름
  1. 클라이언트가 startDate, endDate을 검색 조건으로 넣어서 api 요청
  2. 서버는 해당 값 유효성 검사(null 여부, startDate < endDate)
  3. 조건에 해당하는 일정 리스트 리턴
* 그 외
  * findSchedulesInDateRange 의 경우 jpa로도 가능하지만 직접 쿼리 작성으로 구현했습니다!
    * jpa로 구현하면 받는 매개 변수 순서가 endDate, startDate 라서 순서를 헷갈릴 수 있을 것 같았어요