### PR TITLE
feat: 매물 목록 조회 시 필터링

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 import com.zipline.global.exception.ErrorCode;
 
 public enum PropertyErrorCode implements ErrorCode {
-	PROPERTY_NOT_FOUND("PROPERTY-001", "해당하는 매물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+	PROPERTY_NOT_FOUND("PROPERTY-001", "해당하는 매물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	PROPERTY_TYPE_NOT_FOUND("PROPERTY-002", "존재하지 않는 매물 타입입니다.", HttpStatus.NOT_FOUND),
+	PROPERTY_CATEGORY_NOT_FOUND("PROPERTY-003", "존재하지 않는 매물 카테고리입니다.", HttpStatus.NOT_FOUND);
 
 	private final String code;
 	private final String message;

--- a/apiserver/common/src/main/java/com/zipline/global/request/AgentPropertyFilterRequestDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/request/AgentPropertyFilterRequestDTO.java
@@ -1,0 +1,50 @@
+package com.zipline.global.request;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AgentPropertyFilterRequestDTO {
+	private String legalDistrictCode;
+
+	private String type;
+
+	private String category;
+
+	private BigInteger minDeposit;
+	private BigInteger maxDeposit;
+
+	private BigInteger minMonthlyRent;
+	private BigInteger maxMonthlyRent;
+
+	private BigInteger minPrice;
+	private BigInteger maxPrice;
+
+	private LocalDate minMoveInDate;
+	private LocalDate maxMoveInDate;
+
+	private Boolean petsAllowed;
+
+	private Integer minFloor;
+	private Integer maxFloor;
+
+	private Boolean hasElevator;
+
+	private Integer minConstructionYear;
+	private Integer maxConstructionYear;
+
+	private Integer minParkingCapacity;
+	private Integer maxParkingCapacity;
+
+	private Double minNetArea;
+	private Double maxNetArea;
+
+	private Double minTotalArea;
+	private Double maxTotalArea;
+}

--- a/apiserver/controller/src/main/java/com/zipline/controller/agentProperty/AgentPropertyController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/agentProperty/AgentPropertyController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.agentProperty.AgentPropertyService;
@@ -70,11 +72,12 @@ public class AgentPropertyController {
 	}
 
 	@GetMapping("")
-	public ResponseEntity<ApiResponse<AgentPropertyListResponseDTO>> getPropertyList(PageRequestDTO pageRequestDTO,
+	public ResponseEntity<ApiResponse<AgentPropertyListResponseDTO>> getPropertyList(
+		@ModelAttribute PageRequestDTO pageRequestDTO,
+		@ModelAttribute AgentPropertyFilterRequestDTO agentPropertyFilterRequestDTO,
 		Principal principal) {
 		AgentPropertyListResponseDTO propertyListResponseDTO = agentPropertyService.getAgentPropertyList(pageRequestDTO,
-			Long.parseLong(
-				principal.getName()));
+			Long.parseLong(principal.getName()), agentPropertyFilterRequestDTO);
 
 		ApiResponse<AgentPropertyListResponseDTO> response = ApiResponse.ok("매물 목록 조회 성공", propertyListResponseDTO);
 		return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/apiserver/domain/build.gradle
+++ b/apiserver/domain/build.gradle
@@ -23,8 +23,25 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+java {
+    sourceSets {
+        main {
+            java {
+                srcDirs += file("${project.buildDir}/generated/sources/annotationProcessor/java/main")
+            }
+        }
+    }
 }
 
 tasks.named('bootJar') {

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyQueryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyQueryRepository.java
@@ -1,0 +1,138 @@
+package com.zipline.repository.agentProperty;
+
+import static com.zipline.entity.agentProperty.QAgentProperty.*;
+
+import java.time.Year;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zipline.entity.agentProperty.AgentProperty;
+import com.zipline.entity.enums.PropertyCategory;
+import com.zipline.entity.enums.PropertyType;
+import com.zipline.global.request.AgentPropertyFilterRequestDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AgentPropertyQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<AgentProperty> findFilteredProperties(Long userUid, AgentPropertyFilterRequestDTO filter,
+		Pageable pageable) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(agentProperty.user.uid.eq(userUid))
+			.and(agentProperty.deletedAt.isNull());
+
+		if (filter.getType() != null && !filter.getType().isBlank()) {
+			try {
+				builder.and(agentProperty.type.eq(PropertyType.valueOf(filter.getType())));
+			} catch (IllegalArgumentException ignored) {
+			}
+		}
+
+		if (filter.getCategory() != null && !filter.getCategory().isBlank()) {
+			try {
+				builder.and(agentProperty.realCategory.eq(PropertyCategory.valueOf(filter.getCategory())));
+			} catch (IllegalArgumentException ignored) {
+			}
+		}
+
+		if (filter.getLegalDistrictCode() != null && !filter.getLegalDistrictCode().isBlank()) {
+			builder.and(agentProperty.legalDistrictCode.eq(filter.getLegalDistrictCode()));
+		}
+
+		if (filter.getMinDeposit() != null) {
+			builder.and(agentProperty.deposit.goe(filter.getMinDeposit()));
+		}
+		if (filter.getMaxDeposit() != null) {
+			builder.and(agentProperty.deposit.loe(filter.getMaxDeposit()));
+		}
+
+		if (filter.getMinMonthlyRent() != null) {
+			builder.and(agentProperty.monthlyRent.goe(filter.getMinMonthlyRent()));
+		}
+		if (filter.getMaxMonthlyRent() != null) {
+			builder.and(agentProperty.monthlyRent.loe(filter.getMaxMonthlyRent()));
+		}
+
+		if (filter.getMinPrice() != null) {
+			builder.and(agentProperty.price.goe(filter.getMinPrice()));
+		}
+		if (filter.getMaxPrice() != null) {
+			builder.and(agentProperty.price.loe(filter.getMaxPrice()));
+		}
+
+		if (filter.getMinMoveInDate() != null) {
+			builder.and(agentProperty.moveInDate.goe(filter.getMinMoveInDate()));
+		}
+		if (filter.getMaxMoveInDate() != null) {
+			builder.and(agentProperty.moveInDate.loe(filter.getMaxMoveInDate()));
+		}
+
+		if (filter.getPetsAllowed() != null) {
+			builder.and(agentProperty.petsAllowed.eq(filter.getPetsAllowed()));
+		}
+
+		if (filter.getMinFloor() != null) {
+			builder.and(agentProperty.floor.goe(filter.getMinFloor()));
+		}
+		if (filter.getMaxFloor() != null) {
+			builder.and(agentProperty.floor.loe(filter.getMaxFloor()));
+		}
+
+		if (filter.getHasElevator() != null) {
+			builder.and(agentProperty.hasElevator.eq(filter.getHasElevator()));
+		}
+
+		if (filter.getMinConstructionYear() != null) {
+			builder.and(agentProperty.constructionYear.goe(Year.of(filter.getMinConstructionYear())));
+		}
+		if (filter.getMaxConstructionYear() != null) {
+			builder.and(agentProperty.constructionYear.loe(Year.of(filter.getMaxConstructionYear())));
+		}
+
+		if (filter.getMinParkingCapacity() != null) {
+			builder.and(agentProperty.parkingCapacity.goe(filter.getMinParkingCapacity()));
+		}
+		if (filter.getMaxParkingCapacity() != null) {
+			builder.and(agentProperty.parkingCapacity.loe(filter.getMaxParkingCapacity()));
+		}
+
+		if (filter.getMinNetArea() != null) {
+			builder.and(agentProperty.netArea.goe(filter.getMinNetArea()));
+		}
+		if (filter.getMaxNetArea() != null) {
+			builder.and(agentProperty.netArea.loe(filter.getMaxNetArea()));
+		}
+
+		if (filter.getMinTotalArea() != null) {
+			builder.and(agentProperty.totalArea.goe(filter.getMinTotalArea()));
+		}
+		if (filter.getMaxTotalArea() != null) {
+			builder.and(agentProperty.totalArea.loe(filter.getMaxTotalArea()));
+		}
+
+		List<AgentProperty> result = queryFactory
+			.selectFrom(agentProperty)
+			.where(builder)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(agentProperty.uid.desc())
+			.fetch();
+
+		return PageableExecutionUtils.getPage(result, pageable, () -> queryFactory
+			.select(agentProperty.count())
+			.from(agentProperty)
+			.where(builder)
+			.fetchOne());
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyQueryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyQueryRepository.java
@@ -15,6 +15,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.enums.PropertyCategory;
 import com.zipline.entity.enums.PropertyType;
+import com.zipline.global.exception.agentProperty.PropertyException;
+import com.zipline.global.exception.agentProperty.errorcode.PropertyErrorCode;
 import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -35,14 +37,16 @@ public class AgentPropertyQueryRepository {
 		if (filter.getType() != null && !filter.getType().isBlank()) {
 			try {
 				builder.and(agentProperty.type.eq(PropertyType.valueOf(filter.getType())));
-			} catch (IllegalArgumentException ignored) {
+			} catch (IllegalArgumentException e) {
+				throw new PropertyException(PropertyErrorCode.PROPERTY_TYPE_NOT_FOUND);
 			}
 		}
 
 		if (filter.getCategory() != null && !filter.getCategory().isBlank()) {
 			try {
 				builder.and(agentProperty.realCategory.eq(PropertyCategory.valueOf(filter.getCategory())));
-			} catch (IllegalArgumentException ignored) {
+			} catch (IllegalArgumentException e) {
+				throw new PropertyException(PropertyErrorCode.PROPERTY_CATEGORY_NOT_FOUND);
 			}
 		}
 

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyService.java
@@ -1,5 +1,6 @@
 package com.zipline.service.agentProperty;
 
+import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.service.agentProperty.dto.request.AgentPropertyRequestDTO;
 import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseDTO;
@@ -16,5 +17,6 @@ public interface AgentPropertyService {
 
 	void deleteProperty(Long propertyUid, Long userUid);
 
-	AgentPropertyListResponseDTO getAgentPropertyList(PageRequestDTO pageRequestDTO, Long userUid);
+	AgentPropertyListResponseDTO getAgentPropertyList(PageRequestDTO pageRequestDTO, Long userUid,
+		AgentPropertyFilterRequestDTO detailFilter);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -16,7 +16,9 @@ import com.zipline.global.exception.customer.CustomerException;
 import com.zipline.global.exception.customer.errorcode.CustomerErrorCode;
 import com.zipline.global.exception.user.UserException;
 import com.zipline.global.exception.user.errorcode.UserErrorCode;
+import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
+import com.zipline.repository.agentProperty.AgentPropertyQueryRepository;
 import com.zipline.repository.agentProperty.AgentPropertyRepository;
 import com.zipline.repository.customer.CustomerRepository;
 import com.zipline.repository.user.UserRepository;
@@ -34,6 +36,7 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 	private final AgentPropertyRepository agentPropertyRepository;
 	private final UserRepository userRepository;
 	private final CustomerRepository customerRepository;
+	private final AgentPropertyQueryRepository agentPropertyQueryRepository;
 
 	@Transactional(readOnly = true)
 	public AgentPropertyResponseDTO getProperty(Long propertyUid, Long userUid) {
@@ -97,9 +100,11 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 	}
 
 	@Transactional(readOnly = true)
-	public AgentPropertyListResponseDTO getAgentPropertyList(PageRequestDTO pageRequestDTO, Long userUid) {
-		Page<AgentProperty> agentPropertyPage = agentPropertyRepository.findByUserUidAndDeletedAtIsNull(userUid,
-			pageRequestDTO.toPageable());
+	public AgentPropertyListResponseDTO getAgentPropertyList(PageRequestDTO pageRequestDTO, Long userUid,
+		AgentPropertyFilterRequestDTO detailFilter) {
+		Page<AgentProperty> agentPropertyPage = agentPropertyQueryRepository.findFilteredProperties(
+			userUid, detailFilter, pageRequestDTO.toPageable()
+		);
 		List<PropertyResponseDTO> agentPropertyResponseDTOList = agentPropertyPage.getContent().stream()
 			.map(PropertyResponseDTO::new)
 			.toList();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #246 

## 📝작업 내용
> AgentPropertyFilterRequestDTO 생성 및 필터링 파라미터 정리
> AgentProperty 목록 조회 시 필터링 기능 적용 (type, category, price, area 등)
> AgentPropertyQueryRepository에서 필터 조건별 조회 처리
> PropertyType, PropertyCategory Enum 변환 실패 시 PropertyException 발생
> @ModelAttribute를 이용해 GET 요청의 Query Parameter를 DTO에 매핑
> 기존 전체 조회에서 필터 적용 조회로 변경

## 💬리뷰 요구사항(선택)
> Get 메서드로 필터링 조회를 하기 위해 `AgetPropertyFilterRequestDTO`에 @Setter를 추가했는데 다른 방법이 있다면 말씀해주시면 감사하겠습니다!
> Infrastructure의 `AgentPropertyQueryRepository`에서 `AgentPropertyFilterRequestDTO`를 호출해 해당 dto를 common에 두었는데 괜찮은 방식일까요?