### PR TITLE
feat: 크롤링 서버 동시실행 방지 상태를 구분할수 있게 변경

### DIFF
--- a/crawlerserver/common/src/main/java/com/zipline/global/util/CrawlingStatusManager.java
+++ b/crawlerserver/common/src/main/java/com/zipline/global/util/CrawlingStatusManager.java
@@ -1,39 +1,33 @@
 package com.zipline.global.util;
 
+import org.springframework.stereotype.Component;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
-
 @Component
-@Slf4j
 public class CrawlingStatusManager {
-  private volatile boolean isCrawling = false;
+    private final AtomicBoolean isCrawling = new AtomicBoolean(false);
 
-  public synchronized boolean isCrawling() {
-    return isCrawling;
-  }
-
-  public synchronized void startCrawling() {
-    if (isCrawling) {
-      throw new IllegalStateException("다른 크롤링 작업이 진행 중입니다.");
+    public boolean isCrawling() {
+        return isCrawling.get();
     }
-    isCrawling = true;
-    log.info("=== 크롤링 작업 시작 ===");
-  }
 
-  public synchronized void endCrawling() {
-    isCrawling = false;
-    log.info("=== 크롤링 작업 종료 ===");
-  }
-
-  public synchronized <T> T executeWithLock(Supplier<T> task) {
-    try {
-      startCrawling();
-      return task.get();
-    } finally {
-      endCrawling();
+    public void startCrawling() {
+        if (!isCrawling.compareAndSet(false, true)) {
+            throw new IllegalStateException("다른 크롤링 작업이 진행 중입니다.");
+        }
     }
-  }
+
+    public void endCrawling() {
+        isCrawling.set(false);
+    }
+
+    public <T> T executeWithLock(Supplier<T> task) {
+        startCrawling();
+        try {
+            return task.get();
+        } finally {
+            endCrawling();
+        }
+    }
 }

--- a/crawlerserver/common/src/main/java/com/zipline/global/util/CrawlingStatusUtil.java
+++ b/crawlerserver/common/src/main/java/com/zipline/global/util/CrawlingStatusUtil.java
@@ -1,0 +1,21 @@
+package com.zipline.global.util;
+
+import com.zipline.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import java.util.concurrent.CompletableFuture;
+
+public class CrawlingStatusUtil {
+    public static ResponseEntity<ApiResponse<Void>> checkAndExecute(
+            CrawlingStatusManager crawlingStatusManager, Runnable task, String successMessage) {
+        if (crawlingStatusManager.isCrawling()) {
+            return ResponseEntity.ok(ApiResponse.ok("현재 다른 크롤링 작업이 진행 중입니다."));
+        }
+        CompletableFuture.runAsync(() -> {
+            crawlingStatusManager.executeWithLock(() -> {
+                task.run();
+                return null;
+            });
+        });
+        return ResponseEntity.ok(ApiResponse.ok(successMessage));
+    }
+}

--- a/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/CrawlerController.java
+++ b/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/CrawlerController.java
@@ -19,4 +19,10 @@ public class CrawlerController {
     public ResponseEntity<ApiResponse<Boolean>> getCrawlingStatus() {
         return ResponseEntity.ok(ApiResponse.ok("크롤링 상태 조회", crawlingStatusManager.isCrawling()));
     }
-   } 
+
+    @GetMapping("/is-crawling")
+    public ResponseEntity<ApiResponse<Boolean>> isCrawling() {
+        boolean crawlingStatus = crawlingStatusManager.isCrawling();
+        return ResponseEntity.ok(ApiResponse.ok("현재 크롤링 상태", crawlingStatus));
+    }
+}

--- a/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverMigrationController.java
+++ b/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverMigrationController.java
@@ -1,18 +1,16 @@
 package com.zipline.controller.publicitem;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.http.ResponseEntity;
-
 import com.zipline.global.response.ApiResponse;
 import com.zipline.global.util.CrawlingStatusManager;
 import com.zipline.service.publicItem.NaverRawArticleMigrationService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.zipline.global.util.CrawlingStatusUtil.checkAndExecute;
 
 @RestController
 @RequestMapping("/api/v1/crawl/naver-migration")
@@ -24,34 +22,22 @@ public class NaverMigrationController {
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<Void>> startMigration() {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				migrationService.NaverMigration();
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("네이버 원본 매물 데이터 마이그레이션이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> migrationService.NaverMigration(), 
+			"네이버 원본 매물 데이터 마이그레이션이 시작되었습니다.");
 	}
 
 	@GetMapping("/region/{cortarNo}")
 	public ResponseEntity<ApiResponse<Void>> migrateRegion(@PathVariable Long cortarNo) {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				migrationService.migrateRawArticlesForRegion(cortarNo);
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("지역 " + cortarNo + " 네이버 원본 매물 데이터 마이그레이션이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> migrationService.migrateRawArticlesForRegion(cortarNo), 
+			"지역 " + cortarNo + " 네이버 원본 매물 데이터 마이그레이션이 시작되었습니다.");
 	}
 
 	@GetMapping("/retry")
 	public ResponseEntity<ApiResponse<Void>> retryFailedMigrations() {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				migrationService.retryFailedMigrations();
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("실패한 마이그레이션 재시도가 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> migrationService.retryFailedMigrations(), 
+			"실패한 마이그레이션 재시도가 시작되었습니다.");
 	}
 }

--- a/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverProxyRawArticleController.java
+++ b/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverProxyRawArticleController.java
@@ -1,20 +1,19 @@
 package com.zipline.controller.publicitem;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import com.zipline.domain.dto.publicitem.ProxyStatusDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.global.util.CrawlingStatusManager;
 import com.zipline.infrastructure.publicItem.util.ProxyPool;
 import com.zipline.service.publicItem.ProxyNaverRawArticleService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.zipline.global.util.CrawlingStatusUtil.checkAndExecute;
 
 @RestController
 @RequestMapping("/api/v1/crawl/naver-proxy")
@@ -27,24 +26,16 @@ public class NaverProxyRawArticleController {
 
 	@GetMapping("/all")
 	public ResponseEntity<ApiResponse<Void>> crawlAllRawArticleFromNaverWithProxy() {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				proxyNaverRawArticleService.crawlAndSaveRawArticlesByLevel(3);
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("프록시를 통한 레벨 원본 매물 정보 수집이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager,
+			() -> proxyNaverRawArticleService.crawlAndSaveRawArticlesByLevel(3),
+			"프록시를 통한 레벨 원본 매물 정보 수집이 시작되었습니다.");
 	}
 
 	@GetMapping("/region/{cortarNo}")
 	public ResponseEntity<ApiResponse<Void>> crawlRawArticlesWithProxyByRegion(@PathVariable Long cortarNo) {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				proxyNaverRawArticleService.crawlAndSaveRawArticlesForRegion(cortarNo);
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("프록시를 통한 지역 " + cortarNo + " 원본 매물 정보 수집이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager,
+			() -> proxyNaverRawArticleService.crawlAndSaveRawArticlesForRegion(cortarNo),
+			"프록시를 통한 지역 " + cortarNo + " 원본 매물 정보 수집이 시작되었습니다.");
 	}
 
 	@GetMapping("/status")

--- a/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverRawArticleController.java
+++ b/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/NaverRawArticleController.java
@@ -1,18 +1,18 @@
 package com.zipline.controller.publicitem;
 
-import java.util.concurrent.CompletableFuture;
 
+
+import com.zipline.global.response.ApiResponse;
+import com.zipline.global.util.CrawlingStatusManager;
+import com.zipline.service.publicItem.NaverRawArticleService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.zipline.global.response.ApiResponse;
-import com.zipline.global.util.CrawlingStatusManager;
-import com.zipline.service.publicItem.NaverRawArticleService;
-
-import lombok.RequiredArgsConstructor;
+import static com.zipline.global.util.CrawlingStatusUtil.checkAndExecute;
 
 @RestController
 @RequestMapping("/api/v1/crawl/naver")
@@ -24,23 +24,15 @@ public class NaverRawArticleController {
 
 	@GetMapping("/all")
 	public ResponseEntity<ApiResponse<Void>> crawlAllRawArticleFromNaver() {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				naverRawArticleService.crawlAndSaveRawArticlesByLevel(3);
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("레벨 " + 3 + " 원본 매물 정보 수집이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> naverRawArticleService.crawlAndSaveRawArticlesByLevel(3), 
+			"레벨 " + 3 + " 원본 매물 정보 수집이 시작되었습니다.");
 	}
 
 	@GetMapping("/region/{cortarNo}")
 	public ResponseEntity<ApiResponse<Void>> crawlRawArticlesByRegion(@PathVariable Long cortarNo) {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				naverRawArticleService.crawlAndSaveRawArticlesForRegion(cortarNo);
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("지역 " + cortarNo + " 원본 매물 정보 수집이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> naverRawArticleService.crawlAndSaveRawArticlesForRegion(cortarNo), 
+			"지역 " + cortarNo + " 원본 매물 정보 수집이 시작되었습니다.");
 	}
 }

--- a/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/RegionCrawlController.java
+++ b/crawlerserver/controller/src/main/java/com/zipline/controller/publicitem/RegionCrawlController.java
@@ -1,17 +1,15 @@
 package com.zipline.controller.publicitem;
 
-import java.util.concurrent.CompletableFuture;
-
+import com.zipline.global.response.ApiResponse;
+import com.zipline.global.util.CrawlingStatusManager;
+import com.zipline.service.publicItem.RegionCodeService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.zipline.global.response.ApiResponse;
-import com.zipline.global.util.CrawlingStatusManager;
-import com.zipline.service.publicItem.RegionCodeService;
-
-import lombok.RequiredArgsConstructor;
+import static com.zipline.global.util.CrawlingStatusUtil.checkAndExecute;
 
 @RestController
 @RequestMapping("/api/v1/crawl/region")
@@ -23,12 +21,8 @@ public class RegionCrawlController {
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<Void>> crawlRegions() {
-		CompletableFuture.runAsync(() -> {
-			crawlingStatusManager.executeWithLock(() -> {
-				regionCodeService.crawlAndSaveRegions();
-				return null;
-			});
-		});
-		return ResponseEntity.ok(ApiResponse.ok("지역 정보 수집이 시작되었습니다."));
+		return checkAndExecute(crawlingStatusManager, 
+			() -> regionCodeService.crawlAndSaveRegions(), 
+			"지역 정보 수집이 시작되었습니다.");
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #257 

## 📝작업 내용
>     현재 동시에 두 개의 크롤링이 실행되지 않도록 방지하고 있으나 요청을 보내는 측에서는 상태 조회 요청을 보내야 작업이 진행 중인 것을 확인할 수 있습니다. 추가 요청 없이 확인 가능하도록 수정할 예정입니다.

## 💬리뷰 요구사항(선택)
>    락을 거는 로직을 서비스로 이동할 생각이 있습니다. 다만 어느 컨트롤러에 락이 걸려 있는지 확인하기에는 컨트롤러에 두는 것이 조금 더 명확할 것 같아서 현재 컨트롤러에 두었는데 해당 부분에 대한 의견을 받고 적용할 예정입니다. 현재 컨트롤러에 둔 이유는 명확하지만 원칙상 서비스에 두는 게 맞을 것 같아서 고민입니다. 설계를 많이 바꾸어야되서 만약 적용을 하더라도 추후 적용하는것도 좋은 선택 같다고 생각합니다.

1. 그대로 두기
2. 지금 빠꾸기
3. 추후 변경 

