### PR TITLE
feat: 일정 수정 api 추가

### DIFF
--- a/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/schedule/ScheduleController.java
@@ -4,6 +4,7 @@ import com.zipline.global.response.ApiResponse;
 import com.zipline.service.schedule.ScheduleService;
 import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.request.ScheduleModifyRequestDTO;
 import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,6 +54,17 @@ public class ScheduleController {
     return ResponseEntity.ok(response);
   }
 
+  @PatchMapping("/{scheduleUid}")
+  public ResponseEntity<ApiResponse<ScheduleResponseDTO>> modifySchedule(
+      @PathVariable Long scheduleUid,
+      @Valid @RequestBody ScheduleModifyRequestDTO request,
+      Principal principal) {
+    ScheduleResponseDTO response = scheduleService.modifySchedule(
+        Long.parseLong(principal.getName()), scheduleUid,request);
+
+    ApiResponse<ScheduleResponseDTO> responseBody = ApiResponse.ok("일정 수정 성공", response);
+    return ResponseEntity.ok(responseBody);
+  }
 
   @DeleteMapping("/{scheduleUid}")
   public ResponseEntity<ApiResponse<Void>> deleteSchedule(@PathVariable Long scheduleUid,

--- a/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
@@ -62,14 +62,10 @@ public class Schedule extends BaseTimeEntity {
   public void updateSchedule(String title, String description,
       LocalDateTime startDate, LocalDateTime endDate,
       Customer customer) {
-      this.title = title;
-    if (description != null) {
-      this.description = description;
-    }
-      this.startDate = startDate;
-      this.endDate = endDate;
-    if (customer != null) {
-      this.customer = customer;
-    }
+    this.title = title;
+    this.description = description;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.customer = customer;
   }
 }

--- a/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/schedule/Schedule.java
@@ -57,4 +57,19 @@ public class Schedule extends BaseTimeEntity {
     this.customer = customer;
     this.user = user;
   }
+
+
+  public void updateSchedule(String title, String description,
+      LocalDateTime startDate, LocalDateTime endDate,
+      Customer customer) {
+      this.title = title;
+    if (description != null) {
+      this.description = description;
+    }
+      this.startDate = startDate;
+      this.endDate = endDate;
+    if (customer != null) {
+      this.customer = customer;
+    }
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleFieldUpdateProcessor.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleFieldUpdateProcessor.java
@@ -1,0 +1,42 @@
+package com.zipline.service.schedule;
+
+import com.zipline.entity.customer.Customer;
+import com.zipline.global.exception.customer.CustomerException;
+import com.zipline.global.exception.customer.errorcode.CustomerErrorCode;
+import com.zipline.repository.customer.CustomerRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduleFieldUpdateProcessor {
+  private final CustomerRepository customerRepository;
+
+  public ScheduleFieldUpdateProcessor(CustomerRepository customerRepository) {
+    this.customerRepository = customerRepository;
+  }
+
+
+  public String processUpdate(String newValue, String currentValue, boolean isFieldOmitted) {
+    // 필드가 생략된 경우
+    if (isFieldOmitted) {
+      return currentValue;
+    }
+    // 필드: null로 명시적으로 요청한 경우
+    if (newValue == null) {
+      return null;
+    }
+    return newValue;
+  }
+
+  public Customer processCustomerUpdate(Long customerUid, Customer currentCustomer, boolean isFieldOmitted) {
+    // 필드가 생략된 경우
+    if (isFieldOmitted) {
+      return currentCustomer;
+    }
+    // 필드: null로 명시적으로 요청한 경우
+    if (customerUid == null) {
+      return null;
+    }
+    return customerRepository.findById(customerUid)
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+  }
+}

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleService.java
@@ -2,6 +2,7 @@ package com.zipline.service.schedule;
 
 import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.request.ScheduleModifyRequestDTO;
 import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import java.util.List;
 
@@ -9,5 +10,7 @@ public interface ScheduleService {
 
   void createSchedule(ScheduleCreateRequestDTO request, Long userUid);
   List<ScheduleResponseDTO> getScheduleList(DateRangeRequest request, Long userUid);
+  ScheduleResponseDTO modifySchedule(Long userUid, Long scheduleUid,
+      ScheduleModifyRequestDTO request);
   void deleteSchedule(Long scheduleUid, Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -14,6 +14,7 @@ import com.zipline.repository.schedule.ScheduleRepository;
 import com.zipline.repository.user.UserRepository;
 import com.zipline.service.schedule.dto.request.DateRangeRequest;
 import com.zipline.service.schedule.dto.request.ScheduleCreateRequestDTO;
+import com.zipline.service.schedule.dto.request.ScheduleModifyRequestDTO;
 import com.zipline.service.schedule.dto.response.ScheduleResponseDTO;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -65,6 +66,29 @@ public class ScheduleServiceImpl implements ScheduleService {
         if (startDate.isAfter(endDate)) {
             throw new ScheduleException(ScheduleErrorCode.INVALID_SCHEDULE_TIME);
         }
+    }
+
+    @Override
+    @Transactional
+    public ScheduleResponseDTO modifySchedule(Long userUid, Long scheduleUid,
+        ScheduleModifyRequestDTO request) {
+        validateScheduleTimeRequest(request.getStartDate(), request.getEndDate());
+
+        Schedule schedule = scheduleRepository.findByUidAndUserUidAndDeletedAtIsNull(scheduleUid,
+                userUid)
+            .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+        Customer customer = findCustomerIsExist(request.getCustomerUid());
+
+        schedule.updateSchedule(
+            request.getTitle(),
+            request.getDescription(),
+            request.getStartDate(),
+            request.getEndDate(),
+            customer
+        );
+
+        return ScheduleResponseDTO.from(schedule);
     }
 
     @Override

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -53,11 +53,11 @@ public class ScheduleServiceImpl implements ScheduleService {
         scheduleRepository.save(schedule);
     }
 
-    private Customer findCustomerIsExist(Integer customerId) {
+    private Customer findCustomerIsExist(Long customerId) {
         if (customerId == null) {
             return null;
         }
-        return customerRepository.findById(customerId.longValue())
+        return customerRepository.findById(customerId)
             .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
     }
 

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -30,6 +30,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final UserRepository userRepository;
     private final CustomerRepository customerRepository;
+    private final ScheduleFieldUpdateProcessor scheduleFieldUpdateProcessor;
 
     @Override
     @Transactional
@@ -78,14 +79,24 @@ public class ScheduleServiceImpl implements ScheduleService {
                 userUid)
             .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
-        Customer customer = findCustomerIsExist(request.getCustomerUid());
+        String newDescription = scheduleFieldUpdateProcessor.processUpdate(
+            request.getDescription(),
+            schedule.getDescription(),
+            !request.hasDescription()
+        );
+
+        Customer newCustomer = scheduleFieldUpdateProcessor.processCustomerUpdate(
+            request.getCustomerUid(),
+            schedule.getCustomer(),
+            !request.hasCustomerUid()
+        );
 
         schedule.updateSchedule(
             request.getTitle(),
-            request.getDescription(),
+            newDescription,
             request.getStartDate(),
             request.getEndDate(),
-            customer
+            newCustomer
         );
 
         return ScheduleResponseDTO.from(schedule);

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/ScheduleServiceImpl.java
@@ -40,7 +40,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         User user = userRepository.findById(userUid)
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        Customer customer = findCustomerIsExist(request.getCustomerId());
+        Customer customer = findCustomerIsExist(request.getCustomerUid());
 
 
         Schedule schedule = Schedule.builder()
@@ -55,11 +55,11 @@ public class ScheduleServiceImpl implements ScheduleService {
         scheduleRepository.save(schedule);
     }
 
-    private Customer findCustomerIsExist(Long customerId) {
-        if (customerId == null) {
+    private Customer findCustomerIsExist(Long customerUid) {
+        if (customerUid == null) {
             return null;
         }
-        return customerRepository.findById(customerId)
+        return customerRepository.findById(customerUid)
             .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
     }
 

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
@@ -36,5 +36,5 @@ public class ScheduleCreateRequestDTO {
   @Size(min = 2, max = 200, message = "일정 설명은 2자 이상 200자 이하로 입력해주세요.")
   private String description;
 
-  private Integer customerId;
+  private Long customerId;
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleCreateRequestDTO.java
@@ -36,5 +36,5 @@ public class ScheduleCreateRequestDTO {
   @Size(min = 2, max = 200, message = "일정 설명은 2자 이상 200자 이하로 입력해주세요.")
   private String description;
 
-  private Long customerId;
+  private Long customerUid;
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
@@ -1,5 +1,9 @@
 package com.zipline.service.schedule.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,4 +26,29 @@ public class ScheduleModifyRequestDTO {
 
   private String description;
   private Long customerUid;
+
+  @JsonIgnore
+  private boolean descriptionFieldPresent;
+  @JsonIgnore
+  private boolean customerUidFieldPresent;
+
+  @JsonProperty("description")
+  private void descriptionPresent(String description) {
+    this.description = description;
+    this.descriptionFieldPresent = true;
+  }
+
+  @JsonProperty("customerUid")
+  private void customerUidPresent(Long customerUid) {
+    this.customerUid = customerUid;
+    this.customerUidFieldPresent = true;
+  }
+
+  public boolean hasDescription() {
+    return descriptionFieldPresent;
+  }
+
+  public boolean hasCustomerUid() {
+    return customerUidFieldPresent;
+  }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
@@ -11,9 +11,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ScheduleModifyRequestDTO {
 
+  @NotNull(message = "시작 날짜는 필수 입력값입니다.")
   private LocalDateTime startDate;
+
+  @NotNull(message = "종료 날짜는 필수 입력값입니다.")
   private LocalDateTime endDate;
+
+  @NotBlank(message = "제목은 필수 입력값입니다.")
   private String title;
+
   private String description;
   private Long customerUid;
 }

--- a/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/schedule/dto/request/ScheduleModifyRequestDTO.java
@@ -1,0 +1,19 @@
+package com.zipline.service.schedule.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScheduleModifyRequestDTO {
+
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
+  private String title;
+  private String description;
+  private Long customerUid;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #242

## 📝작업 내용
* 일정 수정 api 추가
  * request 필수 필드: 시작/종료 시간, 제목 ([참고: Validation 명세서](https://www.notion.so/Validation-1d9a3f519ab880989241ea67a59ac0e2?pvs=4#1d9a3f519ab880dc8becfd00d40f282e))
* 그 외
  *  기존 일정 요청 service에서 Integer로 관리하던 customerId을 Long으로 수정

### ✨ 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

* patch 메서드의 특성을 살리고 싶어서 필수값이 아닌 필드는 생략할 수 있도록 구현했는데요,
  1. 명시적으로 null 값이 오는 경우와 (ex: `description: null`)
  2. 필드가 아예 생략되어서 요청되는 경우를 구별하는게 생각보다 어려워서 코드가 지저분해졌어요🥹

* (이 작업 부분은 커밋 참고하시면 됩니다 -> [feat: description, customerUid 필드를 optional하게 받을 수 있도록 코드 추가](https://github.com/Kernel360/Kernel360-KDEV4-ZIPLINE/commit/19c72434d1921dd66c607143546299c221945c2c))
화요일에 멘토님께 여쭤보기는 할건데 이 부분 관련해서 좋은 방법 알고 계신 분은 알려주시면 너무 감사하겠습니당!