### PR TITLE
feat: 계약 상태 변경 히스토리 저장 및 조회 기능 추가

### DIFF
--- a/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
@@ -17,8 +17,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
+import com.zipline.service.contract.ContractHistoryService;
 import com.zipline.service.contract.ContractService;
 import com.zipline.service.contract.dto.request.ContractRequestDTO;
+import com.zipline.service.contract.dto.response.ContractHistoryResponseDTO;
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
 import com.zipline.service.contract.dto.response.ContractResponseDTO;
 
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class ContractController {
 
 	private final ContractService contractService;
+	private final ContractHistoryService contractHistoryService;
 
 	@GetMapping("/{contractUid}")
 	public ResponseEntity<ApiResponse<ContractResponseDTO>> getContract(@PathVariable Long contractUid,
@@ -74,4 +77,13 @@ public class ContractController {
 
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
+
+	@GetMapping("/{contractUid}/histories")
+	public ResponseEntity<ApiResponse<List<ContractHistoryResponseDTO>>> getContractHistories(
+		@PathVariable Long contractUid) {
+		List<ContractHistoryResponseDTO> histories = contractHistoryService.getHistoriesByContractUid(contractUid);
+		ApiResponse<List<ContractHistoryResponseDTO>> response = ApiResponse.ok("계약 히스토리 조회 성공", histories);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
 }

--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/ContractHistory.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/ContractHistory.java
@@ -1,0 +1,52 @@
+package com.zipline.entity.contract;
+
+import java.time.LocalDate;
+
+import com.zipline.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "contract_histories")
+public class ContractHistory extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "uid", nullable = false)
+	private Long uid;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "contract_uid", nullable = false)
+	private Contract contract;
+
+	@Column(name = "prev_status", nullable = false, length = 20)
+	private String prevStatus;
+
+	@Column(name = "current_status", nullable = false, length = 20)
+	private String currentStatus;
+
+	@Column(name = "changed_at", nullable = false)
+	private LocalDate changedAt;
+
+	@Builder
+	public ContractHistory(Contract contract, String prevStatus, String currentStatus, LocalDate changedAt) {
+		this.contract = contract;
+		this.prevStatus = prevStatus;
+		this.currentStatus = currentStatus;
+		this.changedAt = changedAt;
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractHistoryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.zipline.repository.contract;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.zipline.entity.contract.ContractHistory;
+
+@Repository
+public interface ContractHistoryRepository extends JpaRepository<ContractHistory, Long> {
+	List<ContractHistory> findByContractUidOrderByChangedAtDesc(Long contractUid);
+}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractHistoryService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractHistoryService.java
@@ -1,0 +1,14 @@
+package com.zipline.service.contract;
+
+import java.util.List;
+
+import com.zipline.entity.contract.Contract;
+import com.zipline.entity.enums.ContractStatus;
+import com.zipline.service.contract.dto.response.ContractHistoryResponseDTO;
+
+public interface ContractHistoryService {
+
+	void addContractHistory(Contract contract, ContractStatus prevStatus, ContractStatus newStatus);
+
+	List<ContractHistoryResponseDTO> getHistoriesByContractUid(Long contractUid);
+}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractHistoryServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractHistoryServiceImpl.java
@@ -1,0 +1,44 @@
+package com.zipline.service.contract;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zipline.entity.contract.Contract;
+import com.zipline.entity.contract.ContractHistory;
+import com.zipline.entity.enums.ContractStatus;
+import com.zipline.repository.contract.ContractHistoryRepository;
+import com.zipline.service.contract.dto.response.ContractHistoryResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ContractHistoryServiceImpl implements ContractHistoryService {
+
+	private final ContractHistoryRepository contractHistoryRepository;
+
+	@Transactional
+	public void addContractHistory(Contract contract, ContractStatus prevStatus, ContractStatus newStatus) {
+		ContractHistory history = ContractHistory.builder()
+			.contract(contract)
+			.prevStatus(prevStatus.name())
+			.currentStatus(newStatus.name())
+			.changedAt(LocalDate.now())
+			.build();
+
+		contractHistoryRepository.save(history);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ContractHistoryResponseDTO> getHistoriesByContractUid(Long contractUid) {
+
+		List<ContractHistory> histories = contractHistoryRepository.findByContractUidOrderByChangedAtDesc(contractUid);
+
+		return histories.stream()
+			.map(ContractHistoryResponseDTO::from)
+			.toList();
+	}
+}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -171,7 +171,9 @@ public class ContractServiceImpl implements ContractService {
 			newStatus
 		);
 
-		contractHistoryService.addContractHistory(contract, prevStatus, newStatus);
+		if (!prevStatus.equals(newStatus)) {
+			contractHistoryService.addContractHistory(contract, prevStatus, newStatus);
+		}
 
 		List<CustomerContract> customerContracts = customerContractRepository.findAllByContractUid(contractUid);
 		if (customerContracts.isEmpty()) {

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractHistoryResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractHistoryResponseDTO.java
@@ -1,0 +1,28 @@
+package com.zipline.service.contract.dto.response;
+
+import java.time.LocalDate;
+
+import com.zipline.entity.contract.ContractHistory;
+
+import lombok.Getter;
+
+@Getter
+public class ContractHistoryResponseDTO {
+	private String prevStatus;
+	private String currentStatus;
+	private LocalDate changedAt;
+
+	public ContractHistoryResponseDTO(String prevStatus, String currentStatus, LocalDate changedAt) {
+		this.prevStatus = prevStatus;
+		this.currentStatus = currentStatus;
+		this.changedAt = changedAt;
+	}
+
+	public static ContractHistoryResponseDTO from(ContractHistory history) {
+		return new ContractHistoryResponseDTO(
+			history.getPrevStatus(),
+			history.getCurrentStatus(),
+			history.getChangedAt()
+		);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #273 

## 📝작업 내용
> Contract 수정 시 계약 상가 변경되었을 경우에만 ContractHistory를 생성해 저장하도록 기능 추가
> ContractHistory 엔티티 생성
> 특정 계약의 상태 변경 히스토리를 조회하는 API 추가
