### PR TITLE
feat: 계약-매물 연결

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -10,8 +10,8 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_STATUS_NOT_FOUND("CONTRACT-003", "존재하지 않는 계약 상태입니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_DATE_AFTER_START_DATE("CONTRACT-004", "계약일은 계약 시작일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST),
-	CONTRACT_START_DATE_NOT_BEFORE_END_DATE("CONTRACT-005", "계약 시작일은 계약 종료일보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST);
-
+	CONTRACT_START_DATE_NOT_BEFORE_END_DATE("CONTRACT-005", "계약 시작일은 계약 종료일보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST);
 	private final String code;
 	private final String message;
 	private final HttpStatus status;

--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -8,6 +8,7 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_NOT_FOUND("CONTRACT-001", "해당하는 계약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_CUSTOMER_NOT_FOUND("CONTRACT-002", "계약에 연결된 고객을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_STATUS_NOT_FOUND("CONTRACT-003", "존재하지 않는 계약 상태입니다.", HttpStatus.NOT_FOUND),
+	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_DATE_AFTER_START_DATE("CONTRACT-004", "계약일은 계약 시작일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST),
 	CONTRACT_START_DATE_NOT_BEFORE_END_DATE("CONTRACT-005", "계약 시작일은 계약 종료일보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST);
 

--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
@@ -3,11 +3,15 @@ package com.zipline.entity.contract;
 import java.time.LocalDate;
 
 import com.zipline.entity.BaseTimeEntity;
+import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.enums.ContractStatus;
+import com.zipline.entity.enums.PropertyCategory;
 import com.zipline.entity.user.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,7 +40,8 @@ public class Contract extends BaseTimeEntity {
 	private User user;
 
 	@Column(name = "category", length = 20)
-	private String category;
+	@Enumerated(EnumType.STRING)
+	private PropertyCategory category;
 
 	@Column(name = "contract_start_date")
 	private LocalDate contractStartDate;
@@ -53,9 +58,14 @@ public class Contract extends BaseTimeEntity {
 	@Column(name = "expected_contract_end_date")
 	private LocalDate expectedContractEndDate;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "agent_property_uid")
+	private AgentProperty agentProperty;
+
 	@Builder
-	private Contract(User user, String category, LocalDate contractStartDate, LocalDate contractDate,
-		LocalDate contractEndDate, ContractStatus status, LocalDate expectedContractEndDate) {
+	private Contract(User user, PropertyCategory category, LocalDate contractStartDate, LocalDate contractDate,
+		LocalDate contractEndDate, ContractStatus status, LocalDate expectedContractEndDate,
+		AgentProperty agentProperty) {
 		this.user = user;
 		this.category = category;
 		this.contractStartDate = contractStartDate;
@@ -63,9 +73,10 @@ public class Contract extends BaseTimeEntity {
 		this.contractEndDate = contractEndDate;
 		this.status = status;
 		this.expectedContractEndDate = expectedContractEndDate;
+		this.agentProperty = agentProperty;
 	}
 
-	public void modifyContract(String category, LocalDate contractDate, LocalDate contractStartDate,
+	public void modifyContract(PropertyCategory category, LocalDate contractDate, LocalDate contractStartDate,
 		LocalDate contractEndDate, LocalDate expectedContractEndDate, ContractStatus status) {
 		this.category = category;
 		this.contractDate = contractDate;

--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
@@ -1,11 +1,12 @@
 package com.zipline.entity.contract;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 
 import com.zipline.entity.BaseTimeEntity;
 import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.enums.ContractStatus;
-import com.zipline.entity.enums.PropertyCategory;
+import com.zipline.entity.enums.PropertyType;
 import com.zipline.entity.user.User;
 
 import jakarta.persistence.Column;
@@ -41,7 +42,7 @@ public class Contract extends BaseTimeEntity {
 
 	@Column(name = "category", length = 20)
 	@Enumerated(EnumType.STRING)
-	private PropertyCategory category;
+	private PropertyType category;
 
 	@Column(name = "contract_start_date")
 	private LocalDate contractStartDate;
@@ -58,16 +59,29 @@ public class Contract extends BaseTimeEntity {
 	@Column(name = "expected_contract_end_date")
 	private LocalDate expectedContractEndDate;
 
+	@Column(name = "deposit")
+	private BigInteger deposit;
+
+	@Column(name = "monthly_rent")
+	private BigInteger monthlyRent;
+
+	@Column(name = "price")
+	private BigInteger price;
+
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "agent_property_uid")
+	@JoinColumn(name = "agent_property_uid", nullable = false)
 	private AgentProperty agentProperty;
 
 	@Builder
-	private Contract(User user, PropertyCategory category, LocalDate contractStartDate, LocalDate contractDate,
+	private Contract(User user, PropertyType category, BigInteger deposit, BigInteger monthlyRent, BigInteger price,
+		LocalDate contractStartDate, LocalDate contractDate,
 		LocalDate contractEndDate, ContractStatus status, LocalDate expectedContractEndDate,
 		AgentProperty agentProperty) {
 		this.user = user;
 		this.category = category;
+		this.deposit = deposit;
+		this.monthlyRent = monthlyRent;
+		this.price = price;
 		this.contractStartDate = contractStartDate;
 		this.contractDate = contractDate;
 		this.contractEndDate = contractEndDate;
@@ -76,9 +90,13 @@ public class Contract extends BaseTimeEntity {
 		this.agentProperty = agentProperty;
 	}
 
-	public void modifyContract(PropertyCategory category, LocalDate contractDate, LocalDate contractStartDate,
+	public void modifyContract(PropertyType category, BigInteger deposit, BigInteger monthlyRent, BigInteger price,
+		LocalDate contractDate, LocalDate contractStartDate,
 		LocalDate contractEndDate, LocalDate expectedContractEndDate, ContractStatus status) {
 		this.category = category;
+		this.deposit = deposit;
+		this.monthlyRent = monthlyRent;
+		this.price = price;
 		this.contractDate = contractDate;
 		this.contractStartDate = contractStartDate;
 		this.contractEndDate = contractEndDate;

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.zipline.service.agentProperty;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -8,7 +9,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.zipline.entity.agentProperty.AgentProperty;
+import com.zipline.entity.contract.Contract;
+import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.customer.Customer;
+import com.zipline.entity.enums.ContractStatus;
 import com.zipline.entity.user.User;
 import com.zipline.global.exception.agentProperty.PropertyException;
 import com.zipline.global.exception.agentProperty.errorcode.PropertyErrorCode;
@@ -20,6 +24,8 @@ import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.repository.agentProperty.AgentPropertyQueryRepository;
 import com.zipline.repository.agentProperty.AgentPropertyRepository;
+import com.zipline.repository.contract.ContractRepository;
+import com.zipline.repository.contract.CustomerContractRepository;
 import com.zipline.repository.customer.CustomerRepository;
 import com.zipline.repository.user.UserRepository;
 import com.zipline.service.agentProperty.dto.request.AgentPropertyRequestDTO;
@@ -36,6 +42,8 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 	private final AgentPropertyRepository agentPropertyRepository;
 	private final UserRepository userRepository;
 	private final CustomerRepository customerRepository;
+	private final ContractRepository contractRepository;
+	private final CustomerContractRepository customerContractRepository;
 	private final AgentPropertyQueryRepository agentPropertyQueryRepository;
 
 	@Transactional(readOnly = true)
@@ -59,6 +67,22 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		AgentProperty agentProperty = agentPropertyRequestDTO.toEntity(loggedInUser, customer);
 
 		AgentProperty save = agentPropertyRepository.save(agentProperty);
+
+		if (Boolean.TRUE.equals(agentPropertyRequestDTO.getCreateContract())) {
+			Contract contract = Contract.builder()
+				.user(loggedInUser)
+				.category(agentPropertyRequestDTO.getRealCategory())
+				.contractDate(LocalDate.now())
+				.status(ContractStatus.LISTED)
+				.agentProperty(agentProperty)
+				.build();
+			CustomerContract customerContract = CustomerContract.builder()
+				.customer(save.getCustomer())
+				.contract(contract)
+				.build();
+			contractRepository.save(contract);
+			customerContractRepository.save(customerContract);
+		}
 		return AgentPropertyResponseDTO.of(save);
 	}
 

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -71,7 +71,6 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		if (Boolean.TRUE.equals(agentPropertyRequestDTO.getCreateContract())) {
 			Contract contract = Contract.builder()
 				.user(loggedInUser)
-				.category(agentPropertyRequestDTO.getRealCategory())
 				.contractDate(LocalDate.now())
 				.status(ContractStatus.LISTED)
 				.agentProperty(agentProperty)

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -1,6 +1,5 @@
 package com.zipline.service.agentProperty;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -71,7 +70,6 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		if (Boolean.TRUE.equals(agentPropertyRequestDTO.getCreateContract())) {
 			Contract contract = Contract.builder()
 				.user(loggedInUser)
-				.contractDate(LocalDate.now())
 				.status(ContractStatus.LISTED)
 				.agentProperty(agentProperty)
 				.build();

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
@@ -110,6 +110,10 @@ public class AgentPropertyRequestDTO {
 	@Schema(description = "기타 상세 사항", example = "풀옵션, 관리비 별도")
 	private String details;
 
+	@NotNull(message = "계약 생성 여부를 선택해주세요.")
+	@Schema(description = "계약 자동 생성 여부", example = "true", required = true)
+	private Boolean createContract;
+
 	public AgentProperty toEntity(User user, Customer customer) {
 		return AgentProperty.builder()
 			.user(user)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -90,7 +90,12 @@ public class ContractServiceImpl implements ContractService {
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
 		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());
 		contractRequestDTO.validateDateOrder();
-		Contract contract = contractRequestDTO.toEntity(savedUser, status, category);
+		contractRequestDTO.validateProperty();
+		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
+				contractRequestDTO.getPropertyUid(), userUid)
+			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
+
+		Contract contract = contractRequestDTO.toEntity(savedUser, agentProperty, status, category);
 		Contract savedContract = contractRepository.save(contract);
 
 		customerContractRepository.save(CustomerContract.builder()
@@ -161,6 +166,10 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new ContractException(ContractErrorCode.CONTRACT_NOT_FOUND));
 
 		contractRequestDTO.validateDateOrder();
+		contractRequestDTO.validateProperty();
+		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
+				contractRequestDTO.getPropertyUid(), userUid)
+			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
 		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -15,6 +15,7 @@ import com.zipline.entity.contract.ContractDocument;
 import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.customer.Customer;
 import com.zipline.entity.enums.ContractStatus;
+import com.zipline.entity.enums.PropertyCategory;
 import com.zipline.entity.user.User;
 import com.zipline.global.config.S3Folder;
 import com.zipline.global.exception.contract.ContractException;
@@ -162,7 +163,7 @@ public class ContractServiceImpl implements ContractService {
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
 		contract.modifyContract(
-			contractRequestDTO.getCategory(),
+			PropertyCategory.valueOf(contractRequestDTO.getCategory()),
 			contractRequestDTO.getContractDate(),
 			contractRequestDTO.getContractStartDate(),
 			contractRequestDTO.getContractEndDate(),

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -88,8 +88,9 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
+		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());
 		contractRequestDTO.validateDateOrder();
-		Contract contract = contractRequestDTO.toEntity(savedUser, status);
+		Contract contract = contractRequestDTO.toEntity(savedUser, status, category);
 		Contract savedContract = contractRepository.save(contract);
 
 		customerContractRepository.save(CustomerContract.builder()
@@ -162,8 +163,9 @@ public class ContractServiceImpl implements ContractService {
 		contractRequestDTO.validateDateOrder();
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
+		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());
 		contract.modifyContract(
-			PropertyCategory.valueOf(contractRequestDTO.getCategory()),
+			category,
 			contractRequestDTO.getContractDate(),
 			contractRequestDTO.getContractStartDate(),
 			contractRequestDTO.getContractEndDate(),
@@ -193,6 +195,14 @@ public class ContractServiceImpl implements ContractService {
 			return ContractStatus.valueOf(status);
 		} catch (IllegalArgumentException e) {
 			throw new ContractException(ContractErrorCode.CONTRACT_STATUS_NOT_FOUND);
+		}
+	}
+
+	private PropertyCategory validateAndParseCategory(String category) {
+		try {
+			return PropertyCategory.valueOf(category);
+		} catch (IllegalArgumentException e) {
+			throw new ContractException(ContractErrorCode.CONTRACT_CATEGORY_NOT_FOUND);
 		}
 	}
 

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -10,14 +10,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.contract.Contract;
 import com.zipline.entity.contract.ContractDocument;
 import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.customer.Customer;
 import com.zipline.entity.enums.ContractStatus;
-import com.zipline.entity.enums.PropertyCategory;
+import com.zipline.entity.enums.PropertyType;
 import com.zipline.entity.user.User;
 import com.zipline.global.config.S3Folder;
+import com.zipline.global.exception.agentProperty.PropertyException;
+import com.zipline.global.exception.agentProperty.errorcode.PropertyErrorCode;
 import com.zipline.global.exception.contract.ContractException;
 import com.zipline.global.exception.contract.errorcode.ContractErrorCode;
 import com.zipline.global.exception.customer.CustomerException;
@@ -26,6 +29,7 @@ import com.zipline.global.exception.user.UserException;
 import com.zipline.global.exception.user.errorcode.UserErrorCode;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.util.S3FileUploader;
+import com.zipline.repository.agentProperty.AgentPropertyRepository;
 import com.zipline.repository.contract.ContractDocumentRepository;
 import com.zipline.repository.contract.ContractRepository;
 import com.zipline.repository.contract.CustomerContractRepository;
@@ -47,6 +51,7 @@ public class ContractServiceImpl implements ContractService {
 	private final ContractRepository contractRepository;
 	private final ContractDocumentRepository contractDocumentRepository;
 	private final CustomerContractRepository customerContractRepository;
+	private final AgentPropertyRepository agentPropertyRepository;
 	private final S3FileUploader s3FileUploader;
 
 	@Transactional(readOnly = true)
@@ -88,7 +93,7 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
-		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());
+		PropertyType category = validateAndParseCategory(contractRequestDTO.getCategory());
 		contractRequestDTO.validateDateOrder();
 		contractRequestDTO.validateProperty();
 		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
@@ -172,9 +177,12 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
-		PropertyCategory category = validateAndParseCategory(contractRequestDTO.getCategory());
+		PropertyType category = validateAndParseCategory(String.valueOf(contractRequestDTO.getCategory()));
 		contract.modifyContract(
 			category,
+			contractRequestDTO.getDeposit(),
+			contractRequestDTO.getMonthlyRent(),
+			contractRequestDTO.getPrice(),
 			contractRequestDTO.getContractDate(),
 			contractRequestDTO.getContractStartDate(),
 			contractRequestDTO.getContractEndDate(),
@@ -207,9 +215,9 @@ public class ContractServiceImpl implements ContractService {
 		}
 	}
 
-	private PropertyCategory validateAndParseCategory(String category) {
+	private PropertyType validateAndParseCategory(String category) {
 		try {
-			return PropertyCategory.valueOf(category);
+			return PropertyType.valueOf(category);
 		} catch (IllegalArgumentException e) {
 			throw new ContractException(ContractErrorCode.CONTRACT_CATEGORY_NOT_FOUND);
 		}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ContractRequestDTO {
 
-	@Schema(description = "계약 카테고리", example = "APARTMENT")
+	@Schema(description = "계약 카테고리", example = "SALE")
 	private String category;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -49,10 +49,10 @@ public class ContractRequestDTO {
 	@Schema(description = "계약 종료 예상일", example = "2026-05-01")
 	private LocalDate expectedContractEndDate;
 
-	public Contract toEntity(User user, ContractStatus status) {
+	public Contract toEntity(User user, ContractStatus status, PropertyCategory category) {
 		return Contract.builder()
 			.user(user)
-			.category(PropertyCategory.valueOf(this.category))
+			.category(category)
 			.contractDate(this.contractDate)
 			.contractStartDate(this.contractStartDate)
 			.contractEndDate(this.contractEndDate)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zipline.entity.contract.Contract;
 import com.zipline.entity.enums.ContractStatus;
+import com.zipline.entity.enums.PropertyCategory;
 import com.zipline.entity.user.User;
 import com.zipline.global.exception.contract.ContractException;
 import com.zipline.global.exception.contract.errorcode.ContractErrorCode;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ContractRequestDTO {
 
-	@Schema(description = "계약 카테고리", example = "월세")
+	@Schema(description = "계약 카테고리", example = "APARTMENT")
 	private String category;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
@@ -51,7 +52,7 @@ public class ContractRequestDTO {
 	public Contract toEntity(User user, ContractStatus status) {
 		return Contract.builder()
 			.user(user)
-			.category(this.category)
+			.category(PropertyCategory.valueOf(this.category))
 			.contractDate(this.contractDate)
 			.contractStartDate(this.contractStartDate)
 			.contractEndDate(this.contractEndDate)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -1,16 +1,19 @@
 package com.zipline.service.contract.dto.request;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.contract.Contract;
 import com.zipline.entity.enums.ContractStatus;
-import com.zipline.entity.enums.PropertyCategory;
+import com.zipline.entity.enums.PropertyType;
 import com.zipline.entity.user.User;
 import com.zipline.global.exception.contract.ContractException;
 import com.zipline.global.exception.contract.errorcode.ContractErrorCode;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,19 +42,38 @@ public class ContractRequestDTO {
 	@Schema(description = "계약 상태", example = "IN_PROGRESS")
 	private String status;
 
+	@PositiveOrZero(message = "보증금은 0 이상의 값이어야 합니다.")
+	@Schema(description = "보증금", example = "50000000")
+	private BigInteger deposit;
+
+	@PositiveOrZero(message = "월세는 0 이상의 값이어야 합니다.")
+	@Schema(description = "월세", example = "1000000")
+	private BigInteger monthlyRent;
+
+	@PositiveOrZero(message = "매매 가격은 0 이상의 값이어야 합니다.")
+	@Schema(description = "매매 가격", example = "800000000")
+	private BigInteger price;
+
 	@Schema(description = "임대/매도자 고객 UID", example = "1")
 	private Long lessorOrSellerUid;
 
 	@Schema(description = "임차/매수자 고객 UID", example = "2")
 	private Long lesseeOrBuyerUid;
 
+	@Schema(description = "매물 UID", example = "1")
+	private Long propertyUid;
+
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	@Schema(description = "계약 종료 예상일", example = "2026-05-01")
 	private LocalDate expectedContractEndDate;
 
-	public Contract toEntity(User user, ContractStatus status, PropertyCategory category) {
+	public Contract toEntity(User user, AgentProperty agentProperty, ContractStatus status, PropertyType category) {
 		return Contract.builder()
 			.user(user)
+			.agentProperty(agentProperty)
+			.deposit(this.deposit)
+			.monthlyRent(this.monthlyRent)
+			.price(this.price)
 			.category(category)
 			.contractDate(this.contractDate)
 			.contractStartDate(this.contractStartDate)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -69,4 +69,10 @@ public class ContractRequestDTO {
 			throw new ContractException(ContractErrorCode.CONTRACT_START_DATE_NOT_BEFORE_END_DATE);
 		}
 	}
+
+	public void validateProperty() {
+		if (propertyUid == null) {
+			throw new ContractException(ContractErrorCode.PROPERTY_REQUIRED);
+		}
+	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractListResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractListResponseDTO.java
@@ -39,16 +39,18 @@ public class ContractListResponseDTO {
 		private LocalDate contractStartDate;
 		private LocalDate contractEndDate;
 		private ContractStatus status;
+		private String address;
 
 		public ContractListDTO(Contract contract, List<CustomerContract> customerContracts) {
 			this.uid = contract.getUid();
-			this.category = contract.getCategory();
+			this.category = String.valueOf(contract.getCategory());
 			this.contractDate = contract.getContractDate();
 			this.contractStartDate = contract.getContractStartDate();
 			this.contractEndDate = contract.getContractEndDate();
 			this.status = contract.getStatus();
 			this.lessorOrSellerName = customerContracts.get(0).getCustomer().getName();
 			this.lesseeOrBuyerName = findLesseeOrBuyerName(customerContracts);
+			this.address = contract.getAgentProperty() != null ? contract.getAgentProperty().getAddress() : null;
 		}
 
 		private String findLesseeOrBuyerName(List<CustomerContract> customerContracts) {

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
@@ -20,6 +20,7 @@ public class ContractResponseDTO {
 	private String lessorOrSellerName;
 	private String lesseeOrBuyerName;
 	private List<DocumentDTO> documents;
+	private String propertyAddress;
 
 	@Getter
 	public static class DocumentDTO {
@@ -36,7 +37,7 @@ public class ContractResponseDTO {
 		List<DocumentDTO> documents) {
 		return ContractResponseDTO.builder()
 			.uid(contract.getUid())
-			.category(contract.getCategory())
+			.category(String.valueOf(contract.getCategory()))
 			.contractStartDate(contract.getContractStartDate())
 			.contractEndDate(contract.getContractEndDate())
 			.expectedContractEndDate(contract.getExpectedContractEndDate())
@@ -44,6 +45,9 @@ public class ContractResponseDTO {
 			.lessorOrSellerName(lessorOrSellerName)
 			.lesseeOrBuyerName(lesseeOrBuyerName)
 			.documents(documents)
+			.propertyAddress(
+				contract.getAgentProperty() != null ? contract.getAgentProperty().getAddress() : null
+			)
 			.build();
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
@@ -20,6 +20,7 @@ public class ContractResponseDTO {
 	private LocalDate contractStartDate;
 	private LocalDate contractEndDate;
 	private LocalDate expectedContractEndDate;
+	private LocalDate contractDate;
 	private String status;
 	private String lessorOrSellerName;
 	private String lesseeOrBuyerName;
@@ -48,6 +49,7 @@ public class ContractResponseDTO {
 			.contractStartDate(contract.getContractStartDate())
 			.contractEndDate(contract.getContractEndDate())
 			.expectedContractEndDate(contract.getExpectedContractEndDate())
+			.contractDate(contract.getContractDate())
 			.status(contract.getStatus().name())
 			.lessorOrSellerName(lessorOrSellerName)
 			.lesseeOrBuyerName(lesseeOrBuyerName)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
@@ -1,5 +1,6 @@
 package com.zipline.service.contract.dto.response;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,6 +14,9 @@ import lombok.Getter;
 public class ContractResponseDTO {
 	private Long uid;
 	private String category;
+	private BigInteger deposit;
+	private BigInteger monthlyRent;
+	private BigInteger price;
 	private LocalDate contractStartDate;
 	private LocalDate contractEndDate;
 	private LocalDate expectedContractEndDate;
@@ -38,6 +42,9 @@ public class ContractResponseDTO {
 		return ContractResponseDTO.builder()
 			.uid(contract.getUid())
 			.category(String.valueOf(contract.getCategory()))
+			.price(contract.getPrice())
+			.deposit(contract.getDeposit())
+			.monthlyRent(contract.getMonthlyRent())
 			.contractStartDate(contract.getContractStartDate())
 			.contractEndDate(contract.getContractEndDate())
 			.expectedContractEndDate(contract.getExpectedContractEndDate())
@@ -45,9 +52,7 @@ public class ContractResponseDTO {
 			.lessorOrSellerName(lessorOrSellerName)
 			.lesseeOrBuyerName(lesseeOrBuyerName)
 			.documents(documents)
-			.propertyAddress(
-				contract.getAgentProperty() != null ? contract.getAgentProperty().getAddress() : null
-			)
+			.propertyAddress(contract.getAgentProperty().getAddress())
 			.build();
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #275 

## 📝작업 내용
> 계약과 매물 ManyToOne으로 연결
> 계약 카테고리 타입을 PropertyCategory Enum으로 변경

> 매물 등록 시 Boolean으로 계약 생성 여부 체크박스
> AgentPropertyServiceImpl: true인 경우(체크한 경우)에만 계약(LISTED), 계약에 대한 고객, 주소 생성
> 판매, 월세, 전세 가격, 보증금 -> ContractRequestDTO, ContractResponseDTO에 추가
> 계약 등록 시 매물 연결 필수 (주소로 selectBox)
> 계약 카테고리: PropertyType 사용

> 계약 자동 생성이 되면 해당 계약 상세 조회 시 매물 주소 확인 가능
> 계약 목록 조회 시 매물 주소 함께 조회