### PR TITLE
feat: 계약 필터링

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/request/ContractFilterRequestDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/request/ContractFilterRequestDTO.java
@@ -1,0 +1,13 @@
+package com.zipline.global.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ContractFilterRequestDTO {
+	private String period;
+	private String status;
+}

--- a/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.zipline.global.request.ContractFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
 import com.zipline.service.contract.ContractService;
@@ -73,13 +75,17 @@ public class ContractController {
 	}
 
 	@GetMapping("")
-	public ResponseEntity<ApiResponse<ContractListResponseDTO>> getContractList(PageRequestDTO pageRequestDTO,
+	public ResponseEntity<ApiResponse<ContractListResponseDTO>> getContractList(
+		@ModelAttribute PageRequestDTO pageRequestDTO,
+		@ModelAttribute ContractFilterRequestDTO filter,
 		Principal principal) {
-		Long userUid = Long.parseLong(principal.getName());
 
-		ContractListResponseDTO responseDto = contractService.getContractList(pageRequestDTO, userUid);
-		ApiResponse<ContractListResponseDTO> response = ApiResponse.ok("계약 목록 조회 성공", responseDto);
+		ContractListResponseDTO response = contractService.getContractList(
+			pageRequestDTO,
+			Long.parseLong(principal.getName()),
+			filter
+		);
 
-		return ResponseEntity.status(HttpStatus.OK).body(response);
+		return ResponseEntity.ok(ApiResponse.ok("계약 목록 조회 성공", response));
 	}
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractQueryRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractQueryRepository.java
@@ -1,0 +1,71 @@
+package com.zipline.repository.contract;
+
+import static com.zipline.entity.contract.QContract.*;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zipline.entity.contract.Contract;
+import com.zipline.entity.enums.ContractStatus;
+import com.zipline.global.exception.contract.ContractException;
+import com.zipline.global.exception.contract.errorcode.ContractErrorCode;
+import com.zipline.global.request.ContractFilterRequestDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ContractQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<Contract> findFilteredContracts(Long userUid, ContractFilterRequestDTO filter, Pageable pageable) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(contract.user.uid.eq(userUid))
+			.and(contract.deletedAt.isNull());
+
+		if (filter.getPeriod() != null && !filter.getPeriod().equalsIgnoreCase("ALL")) {
+			LocalDate today = LocalDate.now();
+			LocalDate targetDate = switch (filter.getPeriod()) {
+				case "6개월 이내" -> today.plus(6, ChronoUnit.MONTHS);
+				case "3개월 이내" -> today.plus(3, ChronoUnit.MONTHS);
+				case "1개월 이내" -> today.plus(1, ChronoUnit.MONTHS);
+				default -> null;
+			};
+			if (targetDate != null) {
+				builder.and(contract.contractEndDate.loe(targetDate));
+			}
+		}
+
+		if (filter.getStatus() != null && !filter.getStatus().isBlank()) {
+			try {
+				builder.and(contract.status.eq(ContractStatus.valueOf(filter.getStatus())));
+			} catch (IllegalArgumentException e) {
+				throw new ContractException(ContractErrorCode.CONTRACT_STATUS_NOT_FOUND);
+			}
+		}
+
+		List<Contract> result = queryFactory
+			.selectFrom(contract)
+			.where(builder)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(contract.uid.desc())
+			.fetch();
+
+		return PageableExecutionUtils.getPage(result, pageable, () -> queryFactory
+			.select(contract.count())
+			.from(contract)
+			.where(builder)
+			.fetchOne());
+	}
+}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.zipline.global.request.ContractFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.service.contract.dto.request.ContractRequestDTO;
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
@@ -16,10 +17,11 @@ public interface ContractService {
 	ContractResponseDTO registerContract(ContractRequestDTO contractRequestDTO, List<MultipartFile> files,
 		Long userUid);
 
-	ContractListResponseDTO getContractList(PageRequestDTO pageRequestDTO, Long userUid);
-
 	void deleteContract(Long contractUid, Long userUid);
 
 	ContractResponseDTO modifyContract(ContractRequestDTO contractRequestDTO, Long contractUid,
 		List<MultipartFile> files, Long userUid);
+
+	ContractListResponseDTO getContractList(PageRequestDTO pageRequestDTO, Long userUid,
+		ContractFilterRequestDTO filter);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #277 

## 📝작업 내용
> 목록 조회에 기간(6개월 이내, 3개월 이내, 1개월 이내) 필터링 조건 추가
> 계약 상태(ContractStatus) 필터링 조건 추가

> ContractFilterRequestDTO 생성 및 필터링 요청 파라미터 처리
> 기존 getContractList 서비스 로직에 필터링 로직 적용
> ContractQueryRepository 생성 및 findFilteredContracts 메서드 추가 (Querydsl 사용)

> controller 단에서 @ModelAttribute로 필터 요청값 수신하도록 수정

> 기간 필터는 contractEndDate 기준으로 계산
> 필터 조건이 없는 경우 전체 계약 조회
> 잘못된 status 값 요청 시 ContractStatusNotFound 커스텀 에러 반환


> 기타사항: 인프라에 ContractFilterRequestDTO를 두면 controller에서 불러올 수 없어서 인프라용 dto를 만들어야하는데 일단 매물과 똑같이 common에 두었습니다.
