### PR TITLE
fix: 설문 제출시 ULID를 사용하도록 변경

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/config/SecurityConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/SecurityConfig.java
@@ -63,8 +63,8 @@ public class SecurityConfig {
 					"/api/v1/users/reissue", "/api/v1/users/find-id", "/api/v1/users/find-password",
 					"/api/v1/users/reset-password")
 				.permitAll()
-				.requestMatchers(new RegexRequestMatcher("/api/surveys/\\d+$", "GET"),
-					new RegexRequestMatcher("/api/surveys/\\d+/submit$", "POST"))
+				.requestMatchers(new RegexRequestMatcher("/api/v1/surveys/[A-Za-z0-9]+$", "GET"),
+					new RegexRequestMatcher("/api/v1/surveys/[A-Za-z0-9]{26}/submit$$", "POST"))
 				.permitAll()
 				.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs",
 					"/api-docs/**",

--- a/apiserver/controller/src/main/java/com/zipline/controller/survey/SurveyController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/survey/SurveyController.java
@@ -52,9 +52,9 @@ public class SurveyController {
 	}
 
 	@Operation(summary = "설문 조회", description = "공인중개사가 생성한 설문을 조회합니다.")
-	@GetMapping("/surveys/{surveyUid}")
-	public ResponseEntity<ApiResponse<SurveyResponseDTO>> getSurvey(@PathVariable Long surveyUid) {
-		SurveyResponseDTO result = surveyService.getSurvey(surveyUid);
+	@GetMapping("/surveys/{surveyUlid}")
+	public ResponseEntity<ApiResponse<SurveyResponseDTO>> getSurvey(@PathVariable String surveyUlid) {
+		SurveyResponseDTO result = surveyService.getSurvey(surveyUlid);
 		ApiResponse<SurveyResponseDTO> response = ApiResponse.ok("설문 조회 성공", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
@@ -80,12 +80,12 @@ public class SurveyController {
 	}
 
 	@Operation(summary = "설문 제출", description = "고객이 설문을 제출합니다.")
-	@PostMapping(value = "/surveys/{surveyUid}/submit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+	@PostMapping(value = "/surveys/{surveyUlid}/submit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
 		MediaType.APPLICATION_JSON_VALUE})
-	public ResponseEntity<ApiResponse<Void>> submitSurvey(@PathVariable Long surveyUid,
+	public ResponseEntity<ApiResponse<Void>> submitSurvey(@PathVariable String surveyUlid,
 		@RequestPart(name = "requestDTO") List<SurveySubmitRequestDTO> requestDTO,
 		@RequestPart(name = "files", required = false) List<MultipartFile> files) {
-		surveyService.submitSurvey(surveyUid, requestDTO, files);
+		surveyService.submitSurvey(surveyUlid, requestDTO, files);
 		ApiResponse<Void> response = ApiResponse.create("설문 제출에 성공하였습니다.");
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
@@ -12,13 +12,13 @@ import com.zipline.entity.user.User;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
-	@Query("SELECT s FROM Survey s WHERE s.uid = :surveyUid AND s.deletedAt IS NULL")
-	Optional<Survey> findByUidAndDeletedAtIsNull(Long surveyUid);
+	@Query("SELECT s FROM Survey s WHERE s.ulid = :surveyUlid AND s.deletedAt IS NULL")
+	Optional<Survey> findByUlidAndDeleteAtIsNull(String surveyUlid);
 
 	@Query("SELECT s FROM Survey s WHERE s.user.uid = :userUid AND s.deletedAt IS NULL")
 	Optional<Survey> findByUserUidAndDeletedAtIsNull(Long userUid);
 
 	Optional<Survey> findFirstByUserOrderByCreatedAtDesc(User user);
 
-    int countByUserUidAndCreatedAtAfter(Long userId, LocalDateTime oneMonthAgo);
+	int countByUserUidAndCreatedAtAfter(Long userId, LocalDateTime oneMonthAgo);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/survey/SurveyService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/SurveyService.java
@@ -19,9 +19,9 @@ public interface SurveyService {
 
 	void createDefaultSurveyForUser(User user);
 
-	SurveyResponseDTO getSurvey(Long surveyUid);
+	SurveyResponseDTO getSurvey(String surveyUid);
 
-	void submitSurvey(Long surveyUid, List<SurveySubmitRequestDTO> requestDTOList, List<MultipartFile> files);
+	void submitSurvey(String surveyUid, List<SurveySubmitRequestDTO> requestDTOList, List<MultipartFile> files);
 
 	SurveyResponseListDTO getSurveyResponses(PageRequestDTO pageRequestDTO, Long userUid);
 

--- a/apiserver/service/src/main/java/com/zipline/service/survey/SurveyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/survey/SurveyServiceImpl.java
@@ -104,17 +104,17 @@ public class SurveyServiceImpl implements SurveyService {
 	}
 
 	@Transactional(readOnly = true)
-	public SurveyResponseDTO getSurvey(Long surveyUid) {
-		Survey savedSurvey = surveyRepository.findByUidAndDeletedAtIsNull(surveyUid)
+	public SurveyResponseDTO getSurvey(String surveyUlid) {
+		Survey savedSurvey = surveyRepository.findByUlidAndDeleteAtIsNull(surveyUlid)
 			.orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
 		List<Question> questions = questionRepository.findAllBySurveyUidWithChoices(savedSurvey.getUid());
 		return SurveyResponseDTO.from(savedSurvey, questions);
 	}
 
 	@Transactional
-	public void submitSurvey(Long surveyUid, List<SurveySubmitRequestDTO> requestDTOList,
+	public void submitSurvey(String surveyUlid, List<SurveySubmitRequestDTO> requestDTOList,
 		List<MultipartFile> files) {
-		Survey savedSurvey = surveyRepository.findByUidAndDeletedAtIsNull(surveyUid)
+		Survey savedSurvey = surveyRepository.findByUlidAndDeleteAtIsNull(surveyUlid)
 			.orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
 
 		SurveyResponse surveyResponse = new SurveyResponse(savedSurvey, null, LocalDateTime.now());


### PR DESCRIPTION
## #️⃣연관된 이슈

> #282 

## 📝작업 내용
> API EndPoint (SurveyUid) -> SurveyULID로 변경 
> Service SurveyUid가 아닌 SurveyULID로 조회하도록 변경
