### PR TITLE
feat: CustomerResponseDTO에 고객 생일, 관심 지역 값 추가

### DIFF
--- a/apiserver/service/src/main/java/com/zipline/service/customer/dto/response/CustomerListResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/dto/response/CustomerListResponseDTO.java
@@ -37,6 +37,8 @@ public class CustomerListResponseDTO {
 		private boolean isBuyer;
 		private boolean isSeller;
 		private List<LabelDTO> labels;
+		private String legalDistrictCode;
+		private String birthday;
 
 		public CustomerResponseDTO(Customer customer) {
 			this.uid = customer.getUid();
@@ -51,6 +53,8 @@ public class CustomerListResponseDTO {
 				.stream()
 				.map(lc -> new LabelDTO(lc.getLabel().getUid(), lc.getLabel().getName()))
 				.toList() : List.of();
+			this.legalDistrictCode = customer.getLegalDistrictCode();
+			this.birthday = customer.getBirthday();
 		}
 
 		@Getter


### PR DESCRIPTION
## #️⃣연관된 이슈

> #290

## 📝작업 내용

* 단체 문자 발송 시 템플릿 변수로 사용되는 고객의 생일, 관심 지역 값을 받을 수 있도록 CustomerResponseDTO에 해당 변수를 추가합니다.
