### PR TITLE
fix: 계약 등록/수정 시 임대/매도, 임차/매수 고객이 같은 경우 에러처리

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -8,10 +8,11 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_NOT_FOUND("CONTRACT-001", "해당하는 계약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_CUSTOMER_NOT_FOUND("CONTRACT-002", "계약에 연결된 고객을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_STATUS_NOT_FOUND("CONTRACT-003", "존재하지 않는 계약 상태입니다.", HttpStatus.NOT_FOUND),
-	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	CONTRACT_DATE_AFTER_START_DATE("CONTRACT-004", "계약일은 계약 시작일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST),
 	CONTRACT_START_DATE_NOT_BEFORE_END_DATE("CONTRACT-005", "계약 시작일은 계약 종료일보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
-	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST);
+	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
+	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST),
+	SAME_CUSTOMER_FOR_BOTH_PARTIES("CONTRACT-008", "계약의 임대/매도자와 임차/매수자가 동일할 수 없습니다.", HttpStatus.BAD_REQUEST);
 	private final String code;
 	private final String message;
 	private final HttpStatus status;

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -100,6 +100,7 @@ public class ContractServiceImpl implements ContractService {
 		PropertyType category = validateAndParseCategory(contractRequestDTO.getCategory());
 		contractRequestDTO.validateDateOrder();
 		contractRequestDTO.validateProperty();
+		contractRequestDTO.validateDistinctParties();
 		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
 				contractRequestDTO.getPropertyUid(), userUid)
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
@@ -194,6 +195,7 @@ public class ContractServiceImpl implements ContractService {
 
 		contractRequestDTO.validateDateOrder();
 		contractRequestDTO.validateProperty();
+		contractRequestDTO.validateDistinctParties();
 		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
 				contractRequestDTO.getPropertyUid(), userUid)
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -99,7 +99,7 @@ public class ContractRequestDTO {
 	}
 
 	public void validateDistinctParties() {
-		if (lessorOrSellerUid != null && lesseeOrBuyerUid != null && lessorOrSellerUid.equals(lesseeOrBuyerUid)) {
+		if (lessorOrSellerUid != null && lessorOrSellerUid.equals(lesseeOrBuyerUid)) {
 			throw new ContractException(ContractErrorCode.SAME_CUSTOMER_FOR_BOTH_PARTIES);
 		}
 	}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/request/ContractRequestDTO.java
@@ -97,4 +97,11 @@ public class ContractRequestDTO {
 			throw new ContractException(ContractErrorCode.PROPERTY_REQUIRED);
 		}
 	}
+
+	public void validateDistinctParties() {
+		if (lessorOrSellerUid != null && lesseeOrBuyerUid != null && lessorOrSellerUid.equals(lesseeOrBuyerUid)) {
+			throw new ContractException(ContractErrorCode.SAME_CUSTOMER_FOR_BOTH_PARTIES);
+		}
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #299 

## 📝작업 내용
> 계약 등록 시 임대/매도자와 임차/매수자가 동일할 경우 예외 처리 추가
>> ContractRequestDTO에 validateDistinctParties() 메서드 추가
> 두 고객 UID가 같을 경우 ContractException 발생
> ContractErrorCode.SAME_CUSTOMER_FOR_BOTH_PARTIES 추가 (400 Bad Request)
> 계약 등록 서비스 로직에서 해당 유효성 검사 호출 추가
