### PR TITLE
feat: 목록 조회 시 검색 필터링 추가

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/request/ContractFilterRequestDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/request/ContractFilterRequestDTO.java
@@ -10,4 +10,7 @@ import lombok.Setter;
 public class ContractFilterRequestDTO {
 	private String period;
 	private String status;
+	private String category;
+	private String customerName;
+	private String address;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #300 

## 📝작업 내용
> ContractFilterRequestDTO에 `category`, `customerName`, `address` 필드 추가

> ContractQueryRepository에 검색 조건 추가
> `category` - Contract.category 기준 필터링
> `address` - Contract.agentProperty.address 기준 필터링
> `customerName` - 고객 이름이 포함된 계약 UID를 서브 쿼리로 조회하여 필터링
