### PR TITLE
fix: 목록 조회 시 매수자와 매도자 이름 뒤바뀜 수정

### DIFF
--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/CustomerContract.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/CustomerContract.java
@@ -2,9 +2,12 @@ package com.zipline.entity.contract;
 
 import com.zipline.entity.BaseTimeEntity;
 import com.zipline.entity.customer.Customer;
+import com.zipline.entity.enums.ContractCustomerRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,10 +37,15 @@ public class CustomerContract extends BaseTimeEntity {
 	@JoinColumn(name = "contract_uid", nullable = false)
 	private Contract contract;
 
+	@Column(name = "role", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ContractCustomerRole role;
+
 	@Builder
-	private CustomerContract(Customer customer, Contract contract) {
+	private CustomerContract(Customer customer, Contract contract, ContractCustomerRole role) {
 		this.customer = customer;
 		this.contract = contract;
+		this.role = role;
 	}
 
 	public void updateCustomerContract(Customer customer) {

--- a/apiserver/domain/src/main/java/com/zipline/entity/enums/ContractCustomerRole.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/enums/ContractCustomerRole.java
@@ -1,0 +1,6 @@
+package com.zipline.entity.enums;
+
+public enum ContractCustomerRole {
+	LESSOR_OR_SELLER,
+	LESSEE_OR_BUYER
+}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -16,6 +16,7 @@ import com.zipline.entity.contract.Contract;
 import com.zipline.entity.contract.ContractDocument;
 import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.customer.Customer;
+import com.zipline.entity.enums.ContractCustomerRole;
 import com.zipline.entity.enums.ContractStatus;
 import com.zipline.entity.enums.PropertyType;
 import com.zipline.entity.user.User;
@@ -65,16 +66,17 @@ public class ContractServiceImpl implements ContractService {
 
 		List<CustomerContract> customerContracts = customerContractRepository.findAllByContractUid(contractUid);
 
-		if (customerContracts.isEmpty()) {
-			throw new ContractException(ContractErrorCode.CONTRACT_CUSTOMER_NOT_FOUND);
-		}
+		String lessorOrSellerName = customerContracts.stream()
+			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER)
+			.map(cc -> cc.getCustomer().getName())
+			.findFirst()
+			.orElse(null);
 
-		String lessorOrSellerName = customerContracts.get(0).getCustomer().getName();
-
-		String lesseeOrBuyerName = null;
-		if (customerContracts.size() > 1) {
-			lesseeOrBuyerName = customerContracts.get(1).getCustomer().getName();
-		}
+		String lesseeOrBuyerName = customerContracts.stream()
+			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER)
+			.map(cc -> cc.getCustomer().getName())
+			.findFirst()
+			.orElse(null);
 
 		List<ContractDocument> documents = contractDocumentRepository.findAllByContractUid(contractUid);
 		List<ContractResponseDTO.DocumentDTO> documentDTO = documents.stream()
@@ -111,6 +113,7 @@ public class ContractServiceImpl implements ContractService {
 		customerContractRepository.save(CustomerContract.builder()
 			.customer(lessorOrSeller)
 			.contract(savedContract)
+			.role(ContractCustomerRole.LESSOR_OR_SELLER)
 			.build());
 
 		Customer lesseeOrBuyer = null;
@@ -122,6 +125,7 @@ public class ContractServiceImpl implements ContractService {
 				CustomerContract.builder()
 					.customer(lesseeOrBuyer)
 					.contract(savedContract)
+					.role(ContractCustomerRole.LESSEE_OR_BUYER)
 					.build()
 			);
 		}
@@ -265,26 +269,20 @@ public class ContractServiceImpl implements ContractService {
 	}
 
 	private void updateCustomerContracts(Contract contract, List<CustomerContract> customerContracts,
-		ContractRequestDTO dto) {
-		Customer lessorOrSeller = customerRepository.findById(dto.getLessorOrSellerUid())
-			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+		ContractRequestDTO requestDTO) {
 
-		customerContracts.get(0).updateCustomerContract(lessorOrSeller);
-
-		if (dto.getLesseeOrBuyerUid() != null) {
-			Customer lesseeOrBuyer = customerRepository.findById(dto.getLesseeOrBuyerUid())
-				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-
-			if (customerContracts.size() > 1) {
-				customerContracts.get(1).updateCustomerContract(lesseeOrBuyer);
-			} else {
-				customerContractRepository.save(CustomerContract.builder()
-					.customer(lesseeOrBuyer)
-					.contract(contract)
-					.build());
+		for (CustomerContract cc : customerContracts) {
+			if (cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER) {
+				Customer lessorOrSeller = customerRepository.findById(requestDTO.getLessorOrSellerUid())
+					.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+				cc.updateCustomerContract(lessorOrSeller);
+			} else if (cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER) {
+				if (requestDTO.getLesseeOrBuyerUid() != null) {
+					Customer lesseeOrBuyer = customerRepository.findById(requestDTO.getLesseeOrBuyerUid())
+						.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+					cc.updateCustomerContract(lesseeOrBuyer);
+				}
 			}
-		} else if (customerContracts.size() > 1) {
-			customerContractRepository.delete(customerContracts.get(1));
 		}
 	}
 

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractListResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractListResponseDTO.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 
 import com.zipline.entity.contract.Contract;
 import com.zipline.entity.contract.CustomerContract;
+import com.zipline.entity.enums.ContractCustomerRole;
 import com.zipline.entity.enums.ContractStatus;
 
 import lombok.Getter;
@@ -48,16 +49,18 @@ public class ContractListResponseDTO {
 			this.contractStartDate = contract.getContractStartDate();
 			this.contractEndDate = contract.getContractEndDate();
 			this.status = contract.getStatus();
-			this.lessorOrSellerName = customerContracts.get(0).getCustomer().getName();
-			this.lesseeOrBuyerName = findLesseeOrBuyerName(customerContracts);
+			this.lessorOrSellerName = extractCustomerNameByRole(customerContracts,
+				ContractCustomerRole.LESSOR_OR_SELLER);
+			this.lesseeOrBuyerName = extractCustomerNameByRole(customerContracts, ContractCustomerRole.LESSEE_OR_BUYER);
 			this.address = contract.getAgentProperty() != null ? contract.getAgentProperty().getAddress() : null;
 		}
 
-		private String findLesseeOrBuyerName(List<CustomerContract> customerContracts) {
-			if (customerContracts.size() > 1) {
-				return customerContracts.get(1).getCustomer().getName();
-			}
-			return null;
+		private String extractCustomerNameByRole(List<CustomerContract> customerContracts, ContractCustomerRole role) {
+			return customerContracts.stream()
+				.filter(cc -> cc.getRole() == role)
+				.map(cc -> cc.getCustomer().getName())
+				.findFirst()
+				.orElse(null);
 		}
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #311 

## 📝작업 내용
> Customer role 추가 (LESSOR_OR_SELLER, LESSEE_OR_BUYER)
> 목록 조회 시 매도, 매수 구분 후 Response 반환