### PR TITLE
fix: 계약 문서 수정 시 버그 해결

### DIFF
--- a/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/contract/ContractController.java
@@ -69,9 +69,10 @@ public class ContractController {
 		@PathVariable Long contractUid,
 		@RequestPart ContractRequestDTO contractRequestDTO,
 		@RequestPart(required = false) List<MultipartFile> files,
+		@RequestPart(value = "existingDocuments", required = false) List<ContractResponseDTO.DocumentDTO> existingDocs,
 		Principal principal) {
 		ContractResponseDTO contractResponseDTO = contractService.modifyContract(contractRequestDTO, contractUid, files,
-			Long.parseLong(principal.getName()));
+			existingDocs, Long.parseLong(principal.getName()));
 
 		ApiResponse<ContractResponseDTO> response = ApiResponse.ok("계약 수정 성공", contractResponseDTO);
 		return ResponseEntity.ok(response);

--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/Contract.java
@@ -92,7 +92,8 @@ public class Contract extends BaseTimeEntity {
 
 	public void modifyContract(PropertyType category, BigInteger deposit, BigInteger monthlyRent, BigInteger price,
 		LocalDate contractDate, LocalDate contractStartDate,
-		LocalDate contractEndDate, LocalDate expectedContractEndDate, ContractStatus status) {
+		LocalDate contractEndDate, LocalDate expectedContractEndDate, ContractStatus status,
+		AgentProperty agentProperty) {
 		this.category = category;
 		this.deposit = deposit;
 		this.monthlyRent = monthlyRent;
@@ -102,5 +103,6 @@ public class Contract extends BaseTimeEntity {
 		this.contractEndDate = contractEndDate;
 		this.expectedContractEndDate = expectedContractEndDate;
 		this.status = status;
+		this.agentProperty = agentProperty;
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractService.java
@@ -20,7 +20,7 @@ public interface ContractService {
 	void deleteContract(Long contractUid, Long userUid);
 
 	ContractResponseDTO modifyContract(ContractRequestDTO contractRequestDTO, Long contractUid,
-		List<MultipartFile> files, Long userUid);
+		List<MultipartFile> files, List<ContractResponseDTO.DocumentDTO> existingDocs, Long userUid);
 
 	ContractListResponseDTO getContractList(PageRequestDTO pageRequestDTO, Long userUid,
 		ContractFilterRequestDTO filter);

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -1,8 +1,11 @@
 package com.zipline.service.contract;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -189,7 +192,7 @@ public class ContractServiceImpl implements ContractService {
 
 	@Transactional
 	public ContractResponseDTO modifyContract(ContractRequestDTO contractRequestDTO, Long contractUid,
-		List<MultipartFile> files, Long userUid) {
+		List<MultipartFile> files, List<ContractResponseDTO.DocumentDTO> existingDocs, Long userUid) {
 		Contract contract = contractRepository.findByUidAndUserUidAndDeletedAtIsNull(contractUid, userUid)
 			.orElseThrow(() -> new ContractException(ContractErrorCode.CONTRACT_NOT_FOUND));
 
@@ -227,14 +230,15 @@ public class ContractServiceImpl implements ContractService {
 
 		updateCustomerContracts(contract, customerContracts, contractRequestDTO);
 
-		List<ContractResponseDTO.DocumentDTO> documentDTO = updateContractDocuments(contract, contractUid, files);
+		List<ContractResponseDTO.DocumentDTO> updatedDocs = updateContractDocuments(contract, contractUid, files,
+			existingDocs);
 
 		String lesseeOrBuyerName = contractRequestDTO.getLesseeOrBuyerUid() != null
 			? customerRepository.findById(contractRequestDTO.getLesseeOrBuyerUid()).get().getName()
 			: null;
 
 		return ContractResponseDTO.of(contract, customerContracts.get(0).getCustomer().getName(), lesseeOrBuyerName,
-			documentDTO);
+			updatedDocs);
 	}
 
 	private ContractStatus validateAndParseStatus(String status) {
@@ -288,21 +292,39 @@ public class ContractServiceImpl implements ContractService {
 		}
 	}
 
-	private List<ContractResponseDTO.DocumentDTO> updateContractDocuments(Contract contract, Long contractUid,
-		List<MultipartFile> files) {
-		List<ContractDocument> documents;
+	private List<ContractResponseDTO.DocumentDTO> updateContractDocuments(
+		Contract contract,
+		Long contractUid,
+		List<MultipartFile> newFiles,
+		List<ContractResponseDTO.DocumentDTO> existingDocs
+	) {
+		List<ContractDocument> currentDocs = contractDocumentRepository.findAllByContractUid(contractUid);
 
-		if (files != null && !files.isEmpty()) {
-			contractDocumentRepository.deleteAll(contractDocumentRepository.findAllByContractUid(contractUid));
+		Set<String> urlsToKeep = existingDocs != null
+			? existingDocs.stream().map(ContractResponseDTO.DocumentDTO::getFileUrl).collect(Collectors.toSet())
+			: Collections.emptySet();
 
-			List<String> uploadUrls = s3FileUploader.uploadContractFiles(files, S3Folder.CONTRACTS);
-			documents = createContractDocuments(contract, files, uploadUrls);
-			contractDocumentRepository.saveAll(documents);
-		} else {
-			documents = contractDocumentRepository.findAllByContractUid(contractUid);
+		List<ContractDocument> docsToDelete = currentDocs.stream()
+			.filter(doc -> !urlsToKeep.contains(doc.getDocumentUrl()))
+			.toList();
+
+		contractDocumentRepository.deleteAll(docsToDelete);
+
+		List<ContractDocument> savedNewDocs = new ArrayList<>();
+		if (newFiles != null && !newFiles.isEmpty()) {
+			List<String> uploadUrls = s3FileUploader.uploadContractFiles(newFiles, S3Folder.CONTRACTS);
+			savedNewDocs = createContractDocuments(contract, newFiles, uploadUrls);
+			contractDocumentRepository.saveAll(savedNewDocs);
 		}
+		List<ContractDocument> remainingDocs = currentDocs.stream()
+			.filter(doc -> urlsToKeep.contains(doc.getDocumentUrl()))
+			.toList();
 
-		return documents.stream()
+		List<ContractDocument> allDocs = new ArrayList<>();
+		allDocs.addAll(remainingDocs);
+		allDocs.addAll(savedNewDocs);
+
+		return allDocs.stream()
 			.map(doc -> new ContractResponseDTO.DocumentDTO(doc.getDocumentName(), doc.getDocumentUrl()))
 			.toList();
 	}

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -216,7 +216,8 @@ public class ContractServiceImpl implements ContractService {
 			contractRequestDTO.getContractStartDate(),
 			contractRequestDTO.getContractEndDate(),
 			contractRequestDTO.getExpectedContractEndDate(),
-			newStatus
+			newStatus,
+			agentProperty
 		);
 
 		if (!prevStatus.equals(newStatus)) {

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
@@ -8,6 +8,8 @@ import com.zipline.entity.contract.Contract;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Builder
@@ -28,6 +30,8 @@ public class ContractResponseDTO {
 	private String propertyAddress;
 
 	@Getter
+	@NoArgsConstructor
+	@Setter
 	public static class DocumentDTO {
 		private String fileName;
 		private String fileUrl;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #315 

## 📝작업 내용
> ContractController: @RequestPart(`existingDocuments`) 추가
> DocumentDTO에 생성자, @Setter 추가
> ContractService - updateContractDocuments(): 기존 문서 유지/삭제/추가 분리 처리 로직 추가