### PR TITLE
feat: 상담 상세 조회 반환 값 추가

### DIFF
--- a/apiserver/service/src/main/java/com/zipline/service/counsel/dto/response/CounselResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/counsel/dto/response/CounselResponseDTO.java
@@ -1,12 +1,17 @@
 package com.zipline.service.counsel.dto.response;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Year;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.counsel.Counsel;
 import com.zipline.entity.counsel.CounselDetail;
+import com.zipline.entity.customer.Customer;
 
 import lombok.Getter;
 
@@ -19,32 +24,107 @@ public class CounselResponseDTO {
 	private LocalDate dueDate;
 	private Long propertyUid;
 	private boolean completed;
-	private List<CounselDetailResponseDTO> counselDetails;
+	private List<CounselDetailInfo> counselDetails;
+	private CustomerInfo customer;
+	private PropertyInfo property;
 
-	public CounselResponseDTO(Counsel counsel, List<CounselDetail> counselDetails) {
+	public CounselResponseDTO(Counsel counsel, List<CounselDetail> counselDetails, String preferredRegion) {
 		this.counselUid = counsel.getUid();
 		this.title = counsel.getTitle();
-		this.type = counsel.getType().getDescription();
+		this.type = counsel.getType().name().toString();
 		this.counselDate = counsel.getCounselDate();
 		this.dueDate = counsel.getDueDate();
-		this.propertyUid = (counsel.getAgentProperty() != null) ? counsel.getAgentProperty().getUid() : null;
+		this.propertyUid = Optional.ofNullable(counsel.getAgentProperty())
+			.map(AgentProperty::getUid)
+			.orElse(null);
 		this.completed = counsel.isCompleted();
-		this.counselDetails = counselDetails
-			.stream()
-			.map(CounselDetailResponseDTO::new)
+		this.counselDetails = counselDetails.stream()
+			.map(CounselDetailInfo::new)
 			.collect(Collectors.toList());
+		this.customer = new CustomerInfo(counsel.getCustomer(), preferredRegion);
+		this.property = Optional.ofNullable(counsel.getAgentProperty())
+			.map(PropertyInfo::new)
+			.orElse(null);
 	}
 
 	@Getter
-	public static class CounselDetailResponseDTO {
+	public static class CounselDetailInfo {
 		private Long counselDetailUid;
 		private String question;
 		private String answer;
 
-		public CounselDetailResponseDTO(CounselDetail counselDetail) {
+		public CounselDetailInfo(CounselDetail counselDetail) {
 			this.counselDetailUid = counselDetail.getUid();
 			this.question = counselDetail.getQuestion();
 			this.answer = counselDetail.getAnswer();
+		}
+	}
+
+	@Getter
+	public static class CustomerInfo {
+		private Long uid;
+		private String name;
+		private String phoneNo;
+		private boolean isLandlord;
+		private boolean isTenant;
+		private boolean isBuyer;
+		private boolean isSeller;
+		private String preferredRegion;
+		private BigInteger minPrice;
+		private BigInteger maxPrice;
+		private BigInteger minDeposit;
+		private BigInteger maxDeposit;
+		private BigInteger minRent;
+		private BigInteger maxRent;
+
+		public CustomerInfo(Customer customer, String preferredRegion) {
+			this.uid = customer.getUid();
+			this.name = customer.getName();
+			this.phoneNo = customer.getPhoneNo();
+			this.preferredRegion = preferredRegion;
+			this.isLandlord = customer.isLandlord();
+			this.isTenant = customer.isTenant();
+			this.isBuyer = customer.isBuyer();
+			this.isSeller = customer.isSeller();
+			this.minPrice = customer.getMinPrice();
+			this.maxPrice = customer.getMaxPrice();
+			this.minDeposit = customer.getMinDeposit();
+			this.maxDeposit = customer.getMaxDeposit();
+			this.minRent = customer.getMinRent();
+			this.maxRent = customer.getMaxRent();
+		}
+	}
+
+	@Getter
+	public static class PropertyInfo {
+		private String address;
+		private String type;
+		private BigInteger price;
+		private BigInteger deposit;
+		private BigInteger monthlyRent;
+		private Double exclusiveArea;
+		private Double supplyArea;
+		private Integer floor;
+		private Year constructionYear;
+		private boolean hasElevator;
+		private Integer parkingCapacity;
+		private boolean hasPet;
+		private String description;
+
+		public PropertyInfo(AgentProperty property) {
+			this.address = property.getAddress();
+			this.type = property.getRealCategory().name().toString();
+			this.price = property.getPrice();
+			this.deposit = property.getDeposit();
+			this.monthlyRent = property.getMonthlyRent();
+			this.exclusiveArea = property.getTotalArea();
+			this.supplyArea = property.getNetArea();
+			this.floor = property.getFloor();
+			this.constructionYear = property.getConstructionYear();
+			this.hasElevator = property.getHasElevator();
+			this.parkingCapacity = property.getParkingCapacity();
+			this.hasPet = property.getPetsAllowed();
+			this.description = property.getDetails();
 		}
 	}
 }


### PR DESCRIPTION
- 상담 상세 조회 시 고객 정보 및 관련 매물 정보 반환하도록 변경

## #️⃣연관된 이슈

> #320 

## 📝작업 내용
> 상담 상세 조회 시 상담과 연관된 고객의 정보와 매물의 정보도 같이 반환하도록 변경
