### PR TITLE
fix: 계약 카테고리 등록 및 수정 시 입력 버그 수정

### DIFF
--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -97,7 +97,10 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
-		PropertyType category = validateAndParseCategory(contractRequestDTO.getCategory());
+		PropertyType category = null;
+		if (contractRequestDTO.getCategory() != null) {
+			category = validateAndParseCategory(contractRequestDTO.getCategory());
+		}
 		contractRequestDTO.validateDateOrder();
 		contractRequestDTO.validateProperty();
 		contractRequestDTO.validateDistinctParties();
@@ -201,7 +204,10 @@ public class ContractServiceImpl implements ContractService {
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
 
 		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
-		PropertyType category = validateAndParseCategory(String.valueOf(contractRequestDTO.getCategory()));
+		PropertyType category = null;
+		if (contractRequestDTO.getCategory() != null) {
+			category = validateAndParseCategory(String.valueOf(contractRequestDTO.getCategory()));
+		}
 		ContractStatus prevStatus = contract.getStatus();
 		ContractStatus newStatus = validateAndParseStatus(contractRequestDTO.getStatus());
 		contract.modifyContract(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #317 

## 📝작업 내용
> ContractServiceImpl : category 유효성 검사 전 null값 여부 체크