### PR TITLE
 fix: 계약 수정 시 응답 데이터 버그

### DIFF
--- a/apiserver/domain/src/main/java/com/zipline/entity/contract/CustomerContract.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/contract/CustomerContract.java
@@ -48,7 +48,8 @@ public class CustomerContract extends BaseTimeEntity {
 		this.role = role;
 	}
 
-	public void updateCustomerContract(Customer customer) {
+	public void updateCustomerContract(Customer customer, ContractCustomerRole role) {
 		this.customer = customer;
+		this.role = role;
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -69,18 +69,6 @@ public class ContractServiceImpl implements ContractService {
 
 		List<CustomerContract> customerContracts = customerContractRepository.findAllByContractUid(contractUid);
 
-		String lessorOrSellerName = customerContracts.stream()
-			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER)
-			.map(cc -> cc.getCustomer().getName())
-			.findFirst()
-			.orElse(null);
-
-		String lesseeOrBuyerName = customerContracts.stream()
-			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER)
-			.map(cc -> cc.getCustomer().getName())
-			.findFirst()
-			.orElse(null);
-
 		List<ContractDocument> documents = contractDocumentRepository.findAllByContractUid(contractUid);
 		List<ContractResponseDTO.DocumentDTO> documentDTO = documents.stream()
 			.map(doc -> new ContractResponseDTO.DocumentDTO(
@@ -89,7 +77,7 @@ public class ContractServiceImpl implements ContractService {
 			))
 			.toList();
 
-		return ContractResponseDTO.of(contract, lessorOrSellerName, lesseeOrBuyerName, documentDTO);
+		return ContractResponseDTO.of(contract, customerContracts, documentDTO);
 	}
 
 	@Transactional
@@ -115,25 +103,23 @@ public class ContractServiceImpl implements ContractService {
 
 		Contract contract = contractRequestDTO.toEntity(savedUser, agentProperty, status, category);
 		Contract savedContract = contractRepository.save(contract);
+		List<CustomerContract> customerContracts = new ArrayList<>();
 
-		customerContractRepository.save(CustomerContract.builder()
+		customerContracts.add(customerContractRepository.save(CustomerContract.builder()
 			.customer(lessorOrSeller)
 			.contract(savedContract)
 			.role(ContractCustomerRole.LESSOR_OR_SELLER)
-			.build());
+			.build()));
 
-		Customer lesseeOrBuyer = null;
 		if (contractRequestDTO.getLesseeOrBuyerUid() != null) {
-			lesseeOrBuyer = customerRepository.findById(contractRequestDTO.getLesseeOrBuyerUid())
+			Customer lesseeOrBuyer = customerRepository.findById(contractRequestDTO.getLesseeOrBuyerUid())
 				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
-			customerContractRepository.save(
-				CustomerContract.builder()
-					.customer(lesseeOrBuyer)
-					.contract(savedContract)
-					.role(ContractCustomerRole.LESSEE_OR_BUYER)
-					.build()
-			);
+			customerContracts.add(customerContractRepository.save(CustomerContract.builder()
+				.customer(lesseeOrBuyer)
+				.contract(savedContract)
+				.role(ContractCustomerRole.LESSEE_OR_BUYER)
+				.build()));
 		}
 
 		List<ContractResponseDTO.DocumentDTO> documentDTO = List.of();
@@ -147,10 +133,7 @@ public class ContractServiceImpl implements ContractService {
 				.toList();
 		}
 
-		String lesseeOrBuyerName = (contractRequestDTO.getLesseeOrBuyerUid() != null) ?
-			customerRepository.findById(contractRequestDTO.getLesseeOrBuyerUid()).get().getName() : null;
-
-		return ContractResponseDTO.of(savedContract, lessorOrSeller.getName(), lesseeOrBuyerName, documentDTO);
+		return ContractResponseDTO.of(savedContract, customerContracts, documentDTO);
 	}
 
 	@Transactional
@@ -210,10 +193,9 @@ public class ContractServiceImpl implements ContractService {
 				contractRequestDTO.getPropertyUid(), userUid)
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
 
-		ContractStatus status = validateAndParseStatus(contractRequestDTO.getStatus());
 		PropertyType category = null;
 		if (contractRequestDTO.getCategory() != null) {
-			category = validateAndParseCategory(String.valueOf(contractRequestDTO.getCategory()));
+			category = validateAndParseCategory(contractRequestDTO.getCategory());
 		}
 		ContractStatus prevStatus = contract.getStatus();
 		ContractStatus newStatus = validateAndParseStatus(contractRequestDTO.getStatus());
@@ -239,16 +221,15 @@ public class ContractServiceImpl implements ContractService {
 			throw new ContractException(ContractErrorCode.CONTRACT_CUSTOMER_NOT_FOUND);
 		}
 
-		updateCustomerContracts(contract, customerContracts, contractRequestDTO);
+		updateCustomerContracts(customerContracts, contractRequestDTO);
+
+		List<CustomerContract> updatedCustomerContracts =
+			customerContractRepository.findAllByContractUid(contractUid);
 
 		List<ContractResponseDTO.DocumentDTO> updatedDocs = updateContractDocuments(contract, contractUid, files,
 			existingDocs);
 
-		String lesseeOrBuyerName = contractRequestDTO.getLesseeOrBuyerUid() != null
-			? customerRepository.findById(contractRequestDTO.getLesseeOrBuyerUid()).get().getName()
-			: null;
-
-		return ContractResponseDTO.of(contract, customerContracts.get(0).getCustomer().getName(), lesseeOrBuyerName,
+		return ContractResponseDTO.of(contract, updatedCustomerContracts,
 			updatedDocs);
 	}
 
@@ -279,21 +260,49 @@ public class ContractServiceImpl implements ContractService {
 			.toList();
 	}
 
-	private void updateCustomerContracts(Contract contract, List<CustomerContract> customerContracts,
+	private void updateCustomerContracts(List<CustomerContract> customerContracts,
 		ContractRequestDTO requestDTO) {
+		boolean hasLessee = false;
+		boolean hasLessor = false;
 
 		for (CustomerContract cc : customerContracts) {
 			if (cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER) {
 				Customer lessorOrSeller = customerRepository.findById(requestDTO.getLessorOrSellerUid())
 					.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-				cc.updateCustomerContract(lessorOrSeller);
+				cc.updateCustomerContract(lessorOrSeller, ContractCustomerRole.LESSOR_OR_SELLER);
 			} else if (cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER) {
+				hasLessee = true;
 				if (requestDTO.getLesseeOrBuyerUid() != null) {
 					Customer lesseeOrBuyer = customerRepository.findById(requestDTO.getLesseeOrBuyerUid())
 						.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-					cc.updateCustomerContract(lesseeOrBuyer);
+					cc.updateCustomerContract(lesseeOrBuyer, ContractCustomerRole.LESSEE_OR_BUYER);
 				}
 			}
+		}
+		if (!hasLessor) {
+			Customer newLessor = customerRepository.findById(requestDTO.getLessorOrSellerUid())
+				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+			Contract contract = customerContracts.get(0).getContract();
+			customerContractRepository.save(
+				CustomerContract.builder()
+					.contract(contract)
+					.customer(newLessor)
+					.role(ContractCustomerRole.LESSOR_OR_SELLER)
+					.build()
+			);
+		}
+
+		if (!hasLessee && requestDTO.getLesseeOrBuyerUid() != null) {
+			Customer newLessee = customerRepository.findById(requestDTO.getLesseeOrBuyerUid())
+				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+			Contract contract = customerContracts.get(0).getContract();
+			customerContractRepository.save(
+				CustomerContract.builder()
+					.contract(contract)
+					.customer(newLessee)
+					.role(ContractCustomerRole.LESSEE_OR_BUYER)
+					.build()
+			);
 		}
 	}
 

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -263,7 +263,6 @@ public class ContractServiceImpl implements ContractService {
 	private void updateCustomerContracts(List<CustomerContract> customerContracts,
 		ContractRequestDTO requestDTO) {
 		boolean hasLessee = false;
-		boolean hasLessor = false;
 
 		for (CustomerContract cc : customerContracts) {
 			if (cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER) {
@@ -279,23 +278,20 @@ public class ContractServiceImpl implements ContractService {
 				}
 			}
 		}
-		if (!hasLessor) {
-			Customer newLessor = customerRepository.findById(requestDTO.getLessorOrSellerUid())
-				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-			Contract contract = customerContracts.get(0).getContract();
-			customerContractRepository.save(
-				CustomerContract.builder()
-					.contract(contract)
-					.customer(newLessor)
-					.role(ContractCustomerRole.LESSOR_OR_SELLER)
-					.build()
-			);
-		}
+		Customer newLessor = customerRepository.findById(requestDTO.getLessorOrSellerUid())
+			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+		Contract contract = customerContracts.get(0).getContract();
+		customerContractRepository.save(
+			CustomerContract.builder()
+				.contract(contract)
+				.customer(newLessor)
+				.role(ContractCustomerRole.LESSOR_OR_SELLER)
+				.build()
+		);
 
 		if (!hasLessee && requestDTO.getLesseeOrBuyerUid() != null) {
 			Customer newLessee = customerRepository.findById(requestDTO.getLesseeOrBuyerUid())
 				.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
-			Contract contract = customerContracts.get(0).getContract();
 			customerContractRepository.save(
 				CustomerContract.builder()
 					.contract(contract)

--- a/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/dto/response/ContractResponseDTO.java
@@ -5,6 +5,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.zipline.entity.contract.Contract;
+import com.zipline.entity.contract.CustomerContract;
+import com.zipline.entity.enums.ContractCustomerRole;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -42,11 +44,22 @@ public class ContractResponseDTO {
 		}
 	}
 
-	public static ContractResponseDTO of(Contract contract, String lessorOrSellerName, String lesseeOrBuyerName,
+	public static ContractResponseDTO of(Contract contract, List<CustomerContract> customerContracts,
 		List<DocumentDTO> documents) {
+		String lessorOrSellerName = customerContracts.stream()
+			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER)
+			.map(cc -> cc.getCustomer().getName())
+			.findFirst()
+			.orElse(null);
+
+		String lesseeOrBuyerName = customerContracts.stream()
+			.filter(cc -> cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER)
+			.map(cc -> cc.getCustomer().getName())
+			.findFirst()
+			.orElse(null);
 		return ContractResponseDTO.builder()
 			.uid(contract.getUid())
-			.category(String.valueOf(contract.getCategory()))
+			.category(contract.getCategory() != null ? String.valueOf(contract.getCategory()) : null)
 			.price(contract.getPrice())
 			.deposit(contract.getDeposit())
 			.monthlyRent(contract.getMonthlyRent())


### PR DESCRIPTION
## #️⃣연관된 이슈

> #324 

## 📝작업 내용
> ContractResponseDTO.of() 내부에서 CustomerContract 리스트 기반으로 역할에 따라 고객 이름 추출
> 임차/매수자 등록이 되어있지 않은 상태에서 계약 수정으로 고객 등록할 때 새롭게 CustomerContract를 생성
> CustomerContract.updateCustomerContract() 에 role 추가

