### PR TITLE
fix: 매물 생성 및 수정시 버그

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
@@ -7,7 +7,8 @@ import com.zipline.global.exception.ErrorCode;
 public enum PropertyErrorCode implements ErrorCode {
 	PROPERTY_NOT_FOUND("PROPERTY-001", "해당하는 매물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_TYPE_NOT_FOUND("PROPERTY-002", "존재하지 않는 매물 타입입니다.", HttpStatus.NOT_FOUND),
-	PROPERTY_CATEGORY_NOT_FOUND("PROPERTY-003", "존재하지 않는 매물 카테고리입니다.", HttpStatus.NOT_FOUND);
+	PROPERTY_CATEGORY_NOT_FOUND("PROPERTY-003", "존재하지 않는 매물 카테고리입니다.", HttpStatus.NOT_FOUND),
+	INVALID_CONSTRUCTION_YEAR_FORMAT("PROPERTY-004", "유효한 형식의 건축 연도를 입력해주세요.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -63,7 +63,9 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 				agentPropertyRequestDTO.getCustomerUid(), userUid)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
-		agentPropertyRequestDTO.constructionYearValidate();
+		if (agentPropertyRequestDTO.getConstructionYear() != null) {
+			agentPropertyRequestDTO.constructionYearValidate();
+		}
 		AgentProperty agentProperty = agentPropertyRequestDTO.toEntity(loggedInUser, customer);
 
 		AgentProperty save = agentPropertyRepository.save(agentProperty);
@@ -95,7 +97,9 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		Customer customer = customerRepository.findById(agentPropertyRequestDTO.getCustomerUid())
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
-		agentPropertyRequestDTO.constructionYearValidate();
+		if (agentPropertyRequestDTO.getConstructionYear() != null) {
+			agentPropertyRequestDTO.constructionYearValidate();
+		}
 		agentProperty.modifyProperty(customer, agentPropertyRequestDTO.getAddress(),
 			agentPropertyRequestDTO.getLegalDistrictCode(), agentPropertyRequestDTO.getDeposit(),
 			agentPropertyRequestDTO.getMonthlyRent(), agentPropertyRequestDTO.getPrice(),

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -11,6 +11,7 @@ import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.contract.Contract;
 import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.customer.Customer;
+import com.zipline.entity.enums.ContractCustomerRole;
 import com.zipline.entity.enums.ContractStatus;
 import com.zipline.entity.user.User;
 import com.zipline.global.exception.agentProperty.PropertyException;
@@ -78,6 +79,7 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 				.build();
 			CustomerContract customerContract = CustomerContract.builder()
 				.customer(save.getCustomer())
+				.role(ContractCustomerRole.LESSOR_OR_SELLER)
 				.contract(contract)
 				.build();
 			contractRepository.save(contract);

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -63,6 +63,7 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 				agentPropertyRequestDTO.getCustomerUid(), userUid)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
+		agentPropertyRequestDTO.constructionYearValidate();
 		AgentProperty agentProperty = agentPropertyRequestDTO.toEntity(loggedInUser, customer);
 
 		AgentProperty save = agentPropertyRepository.save(agentProperty);
@@ -94,6 +95,7 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		Customer customer = customerRepository.findById(agentPropertyRequestDTO.getCustomerUid())
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
+		agentPropertyRequestDTO.constructionYearValidate();
 		agentProperty.modifyProperty(customer, agentPropertyRequestDTO.getAddress(),
 			agentPropertyRequestDTO.getLegalDistrictCode(), agentPropertyRequestDTO.getDeposit(),
 			agentPropertyRequestDTO.getMonthlyRent(), agentPropertyRequestDTO.getPrice(),

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
@@ -10,6 +10,8 @@ import com.zipline.entity.customer.Customer;
 import com.zipline.entity.enums.PropertyCategory;
 import com.zipline.entity.enums.PropertyType;
 import com.zipline.entity.user.User;
+import com.zipline.global.exception.agentProperty.PropertyException;
+import com.zipline.global.exception.agentProperty.errorcode.PropertyErrorCode;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -139,5 +141,11 @@ public class AgentPropertyRequestDTO {
 			.totalArea(totalArea)
 			.details(details)
 			.build();
+	}
+
+	public void constructionYearValidate() {
+		int year = constructionYear.getValue();
+		if (year < 1000 || year > 9999)
+			throw new PropertyException(PropertyErrorCode.INVALID_CONSTRUCTION_YEAR_FORMAT);
 	}
 }

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/dto/request/AgentPropertyRequestDTO.java
@@ -111,9 +111,8 @@ public class AgentPropertyRequestDTO {
 	@Size(max = 255, message = "상세 정보는 255자 이내로 입력해주세요.")
 	@Schema(description = "기타 상세 사항", example = "풀옵션, 관리비 별도")
 	private String details;
-
-	@NotNull(message = "계약 생성 여부를 선택해주세요.")
-	@Schema(description = "계약 자동 생성 여부", example = "true", required = true)
+	
+	@Schema(description = "계약 자동 생성 여부", example = "true")
 	private Boolean createContract;
 
 	public AgentProperty toEntity(User user, Customer customer) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #334 

## 📝작업 내용
> 매물 등록 및 수정 시 건축년도 1000~9999까지의 4자리 숫자만 입력 가능하도록 유효성 검증
> 관련 에러코드 추가
> 매물 등록에서 계약 자동 생성 체크한 경우 고객 역할 LESSOR_OR_SELLER로 지정
> 계약 자동 생성 여부 선택값으로 변경