### PR TITLE
fix: 클라이언트에서 requestLabelUids가 빈 배열로 들어오는 케이스 처리하도록 코드 추가

### DIFF
--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
@@ -125,7 +125,11 @@ public class CustomerServiceImpl implements CustomerService {
 					.toList();
 				labelCustomerRepository.saveAll(toAddLabelMappings);
 			}
-		}
+		} else if(requestLabelUids != null) {
+				List<LabelCustomer> existingLabelMappings = labelCustomerRepository.findAllByCustomerUid(
+					savedCustomer.getUid());
+				labelCustomerRepository.deleteAll(existingLabelMappings);
+			}
 
 		savedCustomer.modifyCustomer(customerModifyRequestDTO.getName(), customerModifyRequestDTO.getPhoneNo(),
 			customerModifyRequestDTO.getTelProvider(),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #362

## 📝작업 내용
* 클라이언트에서 requestLabelUids가 빈 배열로 들어오는 케이스 처리하도록 코드 추가

* 기존 코드: 기존 코드에서는 if (requestLabelUids != null && !requestLabelUids.isEmpty()) { ... 케이스만 핸들링하고 있었음
* 버그 원인: 클라이언트에서 requestLabelUids가 빈 배열로 들어오는 경우 발생 (기존 고객의 라벨 전부 삭제)
* 해결 방법: 클라이언트에서 requestLabelUids가 빈 배열로 들어오는 케이스 처리하도록 코드 추가


## 📸 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
