### PR TITLE
fix: 중복 생성 시 에러처리

### DIFF
--- a/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/agentProperty/errorcode/PropertyErrorCode.java
@@ -8,7 +8,8 @@ public enum PropertyErrorCode implements ErrorCode {
 	PROPERTY_NOT_FOUND("PROPERTY-001", "해당하는 매물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_TYPE_NOT_FOUND("PROPERTY-002", "존재하지 않는 매물 타입입니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_CATEGORY_NOT_FOUND("PROPERTY-003", "존재하지 않는 매물 카테고리입니다.", HttpStatus.NOT_FOUND),
-	INVALID_CONSTRUCTION_YEAR_FORMAT("PROPERTY-004", "유효한 형식의 건축 연도를 입력해주세요.", HttpStatus.BAD_REQUEST);
+	INVALID_CONSTRUCTION_YEAR_FORMAT("PROPERTY-004", "유효한 형식의 건축 연도를 입력해주세요.", HttpStatus.BAD_REQUEST),
+	DUPLICATED_PROPERTY("PROPERTY-003", "이미 등록되어있는 매물입니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -12,7 +12,9 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_START_DATE_NOT_BEFORE_END_DATE("CONTRACT-005", "계약 시작일은 계약 종료일보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
 	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST),
-	SAME_CUSTOMER_FOR_BOTH_PARTIES("CONTRACT-008", "계약의 임대/매도자와 임차/매수자가 동일할 수 없습니다.", HttpStatus.BAD_REQUEST);
+	SAME_CUSTOMER_FOR_BOTH_PARTIES("CONTRACT-008", "계약의 임대/매도자와 임차/매수자가 동일할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT("CONTRACT-009", "이미 진행 중인 계약이 연결된 매물입니다.", HttpStatus.BAD_REQUEST);
+
 	private final String code;
 	private final String message;
 	private final HttpStatus status;

--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -13,7 +13,8 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST),
 	SAME_CUSTOMER_FOR_BOTH_PARTIES("CONTRACT-008", "계약의 임대/매도자와 임차/매수자가 동일할 수 없습니다.", HttpStatus.BAD_REQUEST),
-	PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT("CONTRACT-009", "이미 진행 중인 계약이 연결된 매물입니다.", HttpStatus.BAD_REQUEST);
+	PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT("CONTRACT-009", "이미 진행 중인 계약이 연결된 매물입니다.", HttpStatus.BAD_REQUEST),
+	DUPLICATE_CONTRACT("CONTRACT-007", "이미 등록된 계약입니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/contract/errorcode/ContractErrorCode.java
@@ -13,7 +13,7 @@ public enum ContractErrorCode implements ErrorCode {
 	CONTRACT_CATEGORY_NOT_FOUND("CONTRACT-006", "존재하지 않는 계약 카테고리입니다.", HttpStatus.NOT_FOUND),
 	PROPERTY_REQUIRED("CONTRACT-007", "매물을 선택해 주세요.", HttpStatus.BAD_REQUEST),
 	SAME_CUSTOMER_FOR_BOTH_PARTIES("CONTRACT-008", "계약의 임대/매도자와 임차/매수자가 동일할 수 없습니다.", HttpStatus.BAD_REQUEST),
-	PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT("CONTRACT-009", "이미 진행 중인 계약이 연결된 매물입니다.", HttpStatus.BAD_REQUEST),
+	PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT("CONTRACT-009", "이미 진행 중인 계약과 연결된 매물입니다.", HttpStatus.BAD_REQUEST),
 	DUPLICATE_CONTRACT("CONTRACT-007", "이미 등록된 계약입니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;

--- a/apiserver/common/src/main/java/com/zipline/global/request/AgentPropertyFilterRequestDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/request/AgentPropertyFilterRequestDTO.java
@@ -55,10 +55,10 @@ public class AgentPropertyFilterRequestDTO {
 	private Integer maxConstructionYear;
 
 	@Min(value = 0, message = "주차 가능 대수는 0 이상이어야 합니다.")
-	private Integer minParkingCapacity;
+	private Double minParkingCapacity;
 
 	@Min(value = 0, message = "주차 가능 대수는 0 이상이어야 합니다.")
-	private Integer maxParkingCapacity;
+	private Double maxParkingCapacity;
 
 	@DecimalMin(value = "0.0", inclusive = true, message = "전용면적은 0 이상이어야 합니다.")
 	private Double minNetArea;

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/agentProperty/AgentPropertyRepository.java
@@ -20,4 +20,9 @@ public interface AgentPropertyRepository extends JpaRepository<AgentProperty, Lo
 
 	Page<AgentProperty> findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(Long customerUid,
 		Long userUid, Pageable pageable);
+
+	@Query("SELECT a FROM AgentProperty a WHERE a.customer.uid = :customerUid AND a.address = :address AND a.detailAddress = :detailAddress AND a.legalDistrictCode = :legalDistrictCode AND a.deletedAt IS NULL")
+	Optional<AgentProperty> findDuplicateProperty(Long customerUid, String address, String detailAddress,
+		String legalDistrictCode);
+
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractRepository.java
@@ -44,4 +44,7 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
 		Long agentPropertyUid,
 		List<ContractStatus> statuses
 	);
+
+	List<Contract> findByAgentPropertyUidAndContractDateAndDeletedAtIsNull(Long propertyUid, LocalDate contractDate);
+
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/ContractRepository.java
@@ -39,4 +39,9 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
 		@Param("userUid") Long userUid,
 		@Param("endDate") LocalDate endDate
 	);
+
+	boolean existsByAgentPropertyUidAndStatusInAndDeletedAtIsNull(
+		Long agentPropertyUid,
+		List<ContractStatus> statuses
+	);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/agentProperty/AgentPropertyServiceImpl.java
@@ -2,6 +2,7 @@ package com.zipline.service.agentProperty;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -63,6 +64,17 @@ public class AgentPropertyServiceImpl implements AgentPropertyService {
 		Customer customer = customerRepository.findByUidAndUserUidAndDeletedAtIsNull(
 				agentPropertyRequestDTO.getCustomerUid(), userUid)
 			.orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+
+		Optional<AgentProperty> duplicate = agentPropertyRepository.findDuplicateProperty(
+			agentPropertyRequestDTO.getCustomerUid(),
+			agentPropertyRequestDTO.getAddress(),
+			agentPropertyRequestDTO.getDetailAddress(),
+			agentPropertyRequestDTO.getLegalDistrictCode()
+		);
+
+		if (duplicate.isPresent()) {
+			throw new PropertyException(PropertyErrorCode.DUPLICATED_PROPERTY);
+		}
 
 		if (agentPropertyRequestDTO.getConstructionYear() != null) {
 			agentPropertyRequestDTO.constructionYearValidate();

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -115,6 +116,32 @@ public class ContractServiceImpl implements ContractService {
 		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
 				contractRequestDTO.getPropertyUid(), userUid)
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));
+
+		List<Contract> duplicates = contractRepository
+			.findByAgentPropertyUidAndContractDateAndDeletedAtIsNull(
+				contractRequestDTO.getPropertyUid(), contractRequestDTO.getContractDate());
+
+		Set<Long> reqLessorUids = Set.copyOf(contractRequestDTO.getLessorOrSellerUids());
+		Set<Long> reqLesseeUids = contractRequestDTO.getLesseeOrBuyerUids() != null
+			? Set.copyOf(contractRequestDTO.getLesseeOrBuyerUids())
+			: Set.of();
+
+		for (Contract c : duplicates) {
+			if (!Objects.equals(c.getCategory(), category) || c.getStatus() != status)
+				continue;
+
+			List<CustomerContract> customers = customerContractRepository.findAllByContractUid(c.getUid());
+			Set<Long> lessors = customers.stream()
+				.filter(cc -> cc.getRole() == ContractCustomerRole.LESSOR_OR_SELLER)
+				.map(cc -> cc.getCustomer().getUid()).collect(Collectors.toSet());
+			Set<Long> lessees = customers.stream()
+				.filter(cc -> cc.getRole() == ContractCustomerRole.LESSEE_OR_BUYER)
+				.map(cc -> cc.getCustomer().getUid()).collect(Collectors.toSet());
+
+			if (lessors.equals(reqLessorUids) && lessees.equals(reqLesseeUids)) {
+				throw new ContractException(ContractErrorCode.DUPLICATE_CONTRACT);
+			}
+		}
 
 		Contract contract = contractRequestDTO.toEntity(savedUser, agentProperty, status, category);
 		Contract savedContract = contractRepository.save(contract);

--- a/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/contract/ContractServiceImpl.java
@@ -102,6 +102,16 @@ public class ContractServiceImpl implements ContractService {
 		contractRequestDTO.validateDateOrder();
 		contractRequestDTO.validateProperty();
 		contractRequestDTO.validateDistinctParties();
+
+		List<ContractStatus> activeStatuses = ContractStatus.getContractedStatuses();
+		boolean hasOngoingContract = contractRepository.existsByAgentPropertyUidAndStatusInAndDeletedAtIsNull(
+			contractRequestDTO.getPropertyUid(),
+			activeStatuses
+		);
+
+		if (hasOngoingContract) {
+			throw new ContractException(ContractErrorCode.PROPERTY_ALREADY_HAS_ACTIVE_CONTRACT);
+		}
 		AgentProperty agentProperty = agentPropertyRepository.findByUidAndUserUidAndDeletedAtIsNull(
 				contractRequestDTO.getPropertyUid(), userUid)
 			.orElseThrow(() -> new PropertyException(PropertyErrorCode.PROPERTY_NOT_FOUND));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #360 

## 📝작업 내용
> 매물 등록 시 기존 등록된 매물과 고객, 주소, 상세주소가 동일한 경우 중복 처리
> 계약 등록 시 기존 등록된 계약과 임대/임차 고객, 계약 상태, 매물, 계약일, 카테고리가 동일한 경우 중복 처리

> 계약 등록 시 해당 계약에 대한 매물이 다른 계약에 이미 등록되어있는 경우 에러 처리
-> 한 매물에 대해 현재 진행 중인 계약은 하나로 처리

> 매물 필터링에서 주차 가능 대수 타입 Double로 변경