### PR TITLE
fix: 최근 유입 고객 수 기준을 설문 응답 제출 수로 변경

### DIFF
--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyAnswerRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyAnswerRepository.java
@@ -1,9 +1,11 @@
 package com.zipline.repository.survey;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.zipline.entity.survey.SurveyAnswer;
 
@@ -14,4 +16,15 @@ public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long
 
 	@Query(value = "SELECT * FROM (SELECT sa.*, ROW_NUMBER() OVER (PARTITION BY sa.survey_response_uid ORDER BY sa.uid ASC) AS rn FROM survey_answers sa WHERE sa.survey_response_uid IN (:savedSurveyResponseIds)) AS sa WHERE sa.rn <= 2", nativeQuery = true)
 	List<SurveyAnswer> findTop2ByResponseIdIn(List<Long> savedSurveyResponseIds);
+
+	@Query("""
+		    SELECT COUNT(DISTINCT sa.surveyResponse.uid)
+		    FROM SurveyAnswer sa
+		    WHERE sa.surveyResponse.survey.user.uid = :userId
+		      AND sa.surveyResponse.createdAt >= :since
+		""")
+	int countRecentResponsesByUser(
+		@Param("userId") Long userId,
+		@Param("since") LocalDateTime since
+	);
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
@@ -1,6 +1,5 @@
 package com.zipline.repository.survey;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,11 +14,5 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
 	@Query("SELECT s FROM Survey s WHERE s.ulid = :surveyUlid AND s.deletedAt IS NULL")
 	Optional<Survey> findByUlidAndDeleteAtIsNull(String surveyUlid);
 
-	@Query("SELECT s FROM Survey s WHERE s.user.uid = :userUid AND s.deletedAt IS NULL")
-	Optional<Survey> findByUserUidAndDeletedAtIsNull(Long userUid);
-
 	Optional<Survey> findFirstByUserOrderByCreatedAtDesc(User user);
-
-	int countByUserUidAndCreatedAtAfter(Long userId, LocalDateTime oneMonthAgo);
-
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/survey/SurveyRepository.java
@@ -21,4 +21,5 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
 	Optional<Survey> findFirstByUserOrderByCreatedAtDesc(User user);
 
 	int countByUserUidAndCreatedAtAfter(Long userId, LocalDateTime oneMonthAgo);
+
 }

--- a/apiserver/service/src/main/java/com/zipline/service/statics/StaticsServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/statics/StaticsServiceImpl.java
@@ -1,57 +1,62 @@
 package com.zipline.service.statics;
 
-import com.zipline.entity.enums.ContractStatus;
-import com.zipline.repository.contract.ContractRepository;
-import com.zipline.repository.survey.SurveyRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.zipline.entity.enums.ContractStatus;
+import com.zipline.repository.contract.ContractRepository;
+import com.zipline.repository.survey.SurveyAnswerRepository;
+import com.zipline.repository.survey.SurveyRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StaticsServiceImpl implements StaticsService {
 
-  private static final int RANGE_FOR_RECENT_DATE = 30;
+	private static final int RANGE_FOR_RECENT_DATE = 30;
 
-  private final ContractRepository contractRepository;
-  private final SurveyRepository surveyRepository;
+	private final ContractRepository contractRepository;
+	private final SurveyRepository surveyRepository;
+	private final SurveyAnswerRepository surveyAnswerRepository;
 
-  @Override
-  public int getRecentContractCount(Long userId) {
-    LocalDateTime oneMonthAgo = LocalDateTime.now().minus(RANGE_FOR_RECENT_DATE, ChronoUnit.DAYS);
-    return contractRepository.countByUserUidAndCreatedAtAfter(userId, oneMonthAgo);
-  }
+	@Override
+	public int getRecentContractCount(Long userId) {
+		LocalDateTime oneMonthAgo = LocalDateTime.now().minus(RANGE_FOR_RECENT_DATE, ChronoUnit.DAYS);
+		return contractRepository.countByUserUidAndCreatedAtAfter(userId, oneMonthAgo);
+	}
 
-  @Override
-  public int getOngoingContractCount(Long userId) {
-    List<ContractStatus> ongoingStatuses = Arrays.asList(
-        ContractStatus.LISTED,
-        ContractStatus.NEGOTIATING,
-        ContractStatus.INTENT_SIGNED,
-        ContractStatus.CONTRACTED,
-        ContractStatus.IN_PROGRESS);
-    return contractRepository.countByUserUidAndStatusIn(userId, ongoingStatuses);
-  }
+	@Override
+	public int getOngoingContractCount(Long userId) {
+		List<ContractStatus> ongoingStatuses = Arrays.asList(
+			ContractStatus.LISTED,
+			ContractStatus.NEGOTIATING,
+			ContractStatus.INTENT_SIGNED,
+			ContractStatus.CONTRACTED,
+			ContractStatus.IN_PROGRESS);
+		return contractRepository.countByUserUidAndStatusIn(userId, ongoingStatuses);
+	}
 
-  @Override
-  public int getCompletedContractCount(Long userId) {
-    List<ContractStatus> completedStatuses = Arrays.asList(
-        ContractStatus.PAID_COMPLETE,
-        ContractStatus.REGISTERED,
-        ContractStatus.MOVED_IN,
-        ContractStatus.TERMINATED);
-    return contractRepository.countByUserUidAndStatusIn(userId, completedStatuses);
-  }
+	@Override
+	public int getCompletedContractCount(Long userId) {
+		List<ContractStatus> completedStatuses = Arrays.asList(
+			ContractStatus.PAID_COMPLETE,
+			ContractStatus.REGISTERED,
+			ContractStatus.MOVED_IN,
+			ContractStatus.TERMINATED);
+		return contractRepository.countByUserUidAndStatusIn(userId, completedStatuses);
+	}
 
-  @Override
-  public int getRecentCustomerCount(Long userId) {
-    LocalDateTime oneMonthAgo = LocalDateTime.now().minus(RANGE_FOR_RECENT_DATE, ChronoUnit.DAYS);
-    return surveyRepository.countByUserUidAndCreatedAtAfter(userId, oneMonthAgo);
-  }
+	@Override
+	public int getRecentCustomerCount(Long userId) {
+		LocalDateTime oneMonthAgo = LocalDateTime.now().minus(RANGE_FOR_RECENT_DATE, ChronoUnit.DAYS);
+		return surveyAnswerRepository.countRecentResponsesByUser(userId, oneMonthAgo);
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #365 

## 📝작업 내용
> SurveyAnswer에서 연결된 SurveyResponse의 createdAt 기준으로 통계 집계하도록 쿼리 변경
> 관련 repository (SurveyAnswerRepository) 및 service (StaticsServiceImpl) 수정