### PR TITLE
feat: 고객 상세 - 상담, 계약 리스트 페이지네이션 추가

### DIFF
--- a/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
@@ -7,7 +7,7 @@ import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseD
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
 import com.zipline.service.counsel.CounselService;
 import com.zipline.service.counsel.dto.request.CounselCreateRequestDTO;
-import com.zipline.service.counsel.dto.response.CounselListResponseDTO;
+import com.zipline.service.counsel.dto.response.CounselPageResponseDTO;
 import com.zipline.service.customer.CustomerService;
 import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
@@ -15,7 +15,6 @@ import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
 import jakarta.validation.Valid;
 import java.security.Principal;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,11 +78,11 @@ public class CustomerController {
 	}
 
 	@GetMapping("/customers/{customerUid}/counsels")
-	public ResponseEntity<ApiResponse<List<CounselListResponseDTO>>> getCustomerCounsels(@PathVariable Long customerUid,
-		Principal principal) {
-		List<CounselListResponseDTO> result = customerService.getCustomerCounsels(customerUid,
+	public ResponseEntity<ApiResponse<CounselPageResponseDTO>> getCustomerCounsels(@PathVariable Long customerUid,
+			PageRequestDTO pageRequestDTO, Principal principal) {
+		CounselPageResponseDTO result = customerService.getCustomerCounsels(customerUid, pageRequestDTO,
 			Long.parseLong(principal.getName()));
-		ApiResponse<List<CounselListResponseDTO>> response = ApiResponse.ok("상담 내역 조회 성공", result);
+		ApiResponse<CounselPageResponseDTO> response = ApiResponse.ok("상담 내역 조회 성공", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 

--- a/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
@@ -1,21 +1,5 @@
 package com.zipline.controller.customer;
 
-import java.security.Principal;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.zipline.global.request.CustomerFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.global.response.ApiResponse;
@@ -29,10 +13,23 @@ import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
 import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
-
 import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -91,11 +88,11 @@ public class CustomerController {
 	}
 
 	@GetMapping("/customers/{customerUid}/contracts")
-	public ResponseEntity<ApiResponse<List<ContractListResponseDTO.ContractListDTO>>> getCustomerContracts(
-		@PathVariable Long customerUid, Principal principal) {
-		List<ContractListResponseDTO.ContractListDTO> result = customerService.getCustomerContracts(
-			customerUid, Long.parseLong(principal.getName()));
-		ApiResponse<List<ContractListResponseDTO.ContractListDTO>> response = ApiResponse.ok("계약 목록 조회 성공", result);
+	public ResponseEntity<ApiResponse<ContractListResponseDTO>> getCustomerContracts(
+		@PathVariable Long customerUid, PageRequestDTO pageRequestDTO, Principal principal) {
+		ContractListResponseDTO result = customerService.getCustomerContracts(
+			customerUid, pageRequestDTO, Long.parseLong(principal.getName()));
+		ApiResponse<ContractListResponseDTO> response = ApiResponse.ok("계약 목록 조회 성공", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/CustomerContractRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/contract/CustomerContractRepository.java
@@ -2,6 +2,8 @@ package com.zipline.repository.contract;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,7 +16,7 @@ public interface CustomerContractRepository extends JpaRepository<CustomerContra
 	List<CustomerContract> findInContractUids(List<Long> contractIds);
 
 	@Query("SELECT cc FROM CustomerContract cc WHERE cc.customer.uid = :customerUid AND cc.contract.user.uid =:userUid ORDER BY cc.contract.contractDate DESC")
-	List<CustomerContract> findByCustomerUidAndUserUid(Long customerUid, Long userUid);
+	Page<CustomerContract> findByCustomerUidAndUserUid(Long customerUid, Long userUid, Pageable pageable);
 
 	List<CustomerContract> findAllByContractUid(Long contractUid);
 

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/counsel/CounselRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/counsel/CounselRepository.java
@@ -1,5 +1,6 @@
 package com.zipline.repository.counsel;
 
+import com.zipline.entity.counsel.Counsel;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,12 +9,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import com.zipline.entity.counsel.Counsel;
-
 public interface CounselRepository extends JpaRepository<Counsel, Long>, QCounselRepository {
 	Optional<Counsel> findByUidAndUserUidAndDeletedAtIsNull(Long uid, Long userUid);
 
 	List<Counsel> findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(Long customerUid, Long userUid);
+
+	Page<Counsel> findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(Long customerUid, Long userUid, Pageable pageable);
 
 	@Query("SELECT c FROM Counsel c JOIN FETCH c.customer WHERE c.user.uid = :userUid AND c.agentProperty.uid = :propertyUid AND c.deletedAt IS NULL ORDER BY c.counselDate desc")
 	Page<Counsel> findByUserUidAndAgentPropertyUidAndDeletedAtIsNull(Long userUid, Long propertyUid, Pageable pageable);

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
@@ -1,7 +1,5 @@
 package com.zipline.service.customer;
 
-import java.util.List;
-
 import com.zipline.global.request.CustomerFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseDTO;
@@ -11,6 +9,7 @@ import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
 import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
+import java.util.List;
 
 public interface CustomerService {
 
@@ -30,5 +29,6 @@ public interface CustomerService {
 
 	AgentPropertyListResponseDTO getCustomerProperties(Long customerUid, PageRequestDTO pageRequestDTO, Long userUid);
 
-	List<ContractListResponseDTO.ContractListDTO> getCustomerContracts(Long customerUid, Long userUid);
+
+	ContractListResponseDTO getCustomerContracts(Long customerUid, PageRequestDTO pageRequestDTO, Long userUid);
 }

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerService.java
@@ -4,12 +4,11 @@ import com.zipline.global.request.CustomerFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
 import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseDTO;
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
-import com.zipline.service.counsel.dto.response.CounselListResponseDTO;
+import com.zipline.service.counsel.dto.response.CounselPageResponseDTO;
 import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
 import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
-import java.util.List;
 
 public interface CustomerService {
 
@@ -25,7 +24,7 @@ public interface CustomerService {
 
 	CustomerDetailResponseDTO getCustomer(Long customerUid, Long userUid);
 
-	List<CounselListResponseDTO> getCustomerCounsels(Long customerUid, Long userUid);
+	CounselPageResponseDTO getCustomerCounsels(Long customerUid, PageRequestDTO pageRequestDTO, Long userUid);
 
 	AgentPropertyListResponseDTO getCustomerProperties(Long customerUid, PageRequestDTO pageRequestDTO, Long userUid);
 

--- a/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/customer/CustomerServiceImpl.java
@@ -1,17 +1,5 @@
 package com.zipline.service.customer;
 
-import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-
 import com.zipline.entity.agentProperty.AgentProperty;
 import com.zipline.entity.contract.CustomerContract;
 import com.zipline.entity.counsel.Counsel;
@@ -39,13 +27,23 @@ import com.zipline.repository.user.UserRepository;
 import com.zipline.service.agentProperty.dto.response.AgentPropertyListResponseDTO;
 import com.zipline.service.contract.dto.response.ContractListResponseDTO;
 import com.zipline.service.counsel.dto.response.CounselListResponseDTO;
+import com.zipline.service.counsel.dto.response.CounselPageResponseDTO;
 import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
 import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
-
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -193,11 +191,20 @@ public class CustomerServiceImpl implements CustomerService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<CounselListResponseDTO> getCustomerCounsels(Long customerUid, Long userUid) {
+	public CounselPageResponseDTO getCustomerCounsels(Long customerUid, PageRequestDTO pageRequestDTO, Long userUid) {
 		validateCustomerExistence(customerUid, userUid);
-		List<Counsel> savedCounsels = counselRepository.findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(
-			customerUid, userUid);
-		return savedCounsels.stream().map(CounselListResponseDTO::createWithoutCustomerName).toList();
+		Page<Counsel> savedCounsels = counselRepository.findByCustomerUidAndUserUidAndDeletedAtIsNullOrderByCreatedAtDesc(
+			customerUid, userUid, pageRequestDTO.toPageable()
+		);
+
+		List<CounselListResponseDTO> data =  savedCounsels.getContent()
+				.stream()
+				.map(CounselListResponseDTO::createWithoutCustomerName)
+				.toList();
+
+
+		return new CounselPageResponseDTO(savedCounsels, data);
+
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #361

## 📝작업 내용
* 고객 상세 - 상담 리스트 페이지네이션 추가
* 고객 상세 - 계약 리스트 페이지네이션 추가
## 📸 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
~~* 상담 페이지네이션 부분에서 DTO 관련 코드 수정을 하면서 `createWithCustomerName` 관련 코드 구조가 살짝 바뀌었는데 이 부분 신경써서 봐주시면 감사하겠습니다 🥹~~ -> `CounselPageResponseDTO` 사용해서 해결
