### PR TITLE
feat: 엑셀 업로드 - 고객, 매물

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -113,6 +113,7 @@ jobs:
             SMS_FROM_NUMBER=${{ secrets.SMS_FROM_NUMBER }}
             SURVEY_DELIMITER=${{ secrets.SURVEY_DELIMITER }}
             MAX_HTTP_TOMCAT_FORM_POST_SIZE=${{ secrets.MAX_HTTP_TOMCAT_FORM_POST_SIZE }}
+            KAKAO_API_KEY=${{secrets.KAKAO_API_KEY}}
             SPRING_PROFILES_ACTIVE=dev
             EOF
             

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -111,6 +111,7 @@ jobs:
             SMS_FROM_NUMBER=${{ secrets.SMS_FROM_NUMBER }}
             SURVEY_DELIMITER=${{ secrets.SURVEY_DELIMITER }}
             MAX_HTTP_TOMCAT_FORM_POST_SIZE=${{ secrets.MAX_HTTP_TOMCAT_FORM_POST_SIZE }}
+            KAKAO_API_KEY=${{secrets.KAKAO_API_KEY}}
             SPRING_PROFILES_ACTIVE=test
             EOF
             

--- a/apiserver/common/build.gradle
+++ b/apiserver/common/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
     // ULID
     implementation("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0")
+
+    implementation "org.apache.poi:poi:5.2.3"
+    implementation "org.apache.poi:poi-ooxml:5.2.3"
 }
 
 tasks.named('test') {

--- a/apiserver/common/src/main/java/com/zipline/global/config/RestClientConfig.java
+++ b/apiserver/common/src/main/java/com/zipline/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.zipline.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import com.zipline.global.exception.common.errorcode.CommonErrorCode;
+import com.zipline.global.exception.excel.ExcelException;
 import com.zipline.global.response.ExceptionResponseDTO;
 
 import lombok.extern.slf4j.Slf4j;
@@ -17,18 +18,15 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	// @ExceptionHandler(JwtException.class)
-	// public ResponseEntity<String> handleJwtException(JwtException e) {
-	// 	log.error(e.getMessage(), e);
-	// 	ErrorCode errorCode = JwtExceptionMessageToErrorCode(e.getMessage());
-	// 	JSONObject jsonObject = ApiResponse.jsonOf(errorCode);
-	//
-	// 	return ResponseEntity.status(errorCode.getHttpStatus())
-	// 		.contentType(MediaType.APPLICATION_JSON)
-	// 		.body(jsonObject.toJSONString());
-	//
-	// }
-	//
+	@ExceptionHandler(ExcelException.class)
+	public ResponseEntity<ExceptionResponseDTO> handleException(ExcelException e) {
+		log.error(e.getMessage(), e);
+		ErrorCode errorCode = e.getErrorCode();
+		ExceptionResponseDTO response = ExceptionResponseDTO.of(errorCode.getCode(), errorCode.getMessage(),
+			e.getDetails());
+		return ResponseEntity.status(errorCode.getStatus()).body(response);
+	}
+
 	@ExceptionHandler(BaseException.class)
 	public ResponseEntity<ExceptionResponseDTO> handleException(BaseException e) {
 		log.error(e.getMessage(), e);

--- a/apiserver/common/src/main/java/com/zipline/global/exception/excel/ExcelException.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/excel/ExcelException.java
@@ -1,0 +1,30 @@
+package com.zipline.global.exception.excel;
+
+import java.util.List;
+import java.util.Map;
+
+import com.zipline.global.exception.BaseException;
+import com.zipline.global.exception.ErrorCode;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+
+public class ExcelException extends BaseException {
+	private List<Map<String, Object>> details;
+
+	public ExcelException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ExcelException(ErrorCode errorCode, int rowNum, String field, Object value, String message) {
+		super(errorCode);
+		this.details = List.of(Map.of("rowNum", rowNum, "field", field, "value", value, "message", message));
+	}
+
+	public ExcelException(ExcelErrorCode errorCode, List<Map<String, Object>> details) {
+		super(errorCode);
+		this.details = details;
+	}
+
+	public List<Map<String, Object>> getDetails() {
+		return details;
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/exception/excel/errorcode/ExcelErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/excel/errorcode/ExcelErrorCode.java
@@ -1,0 +1,37 @@
+package com.zipline.global.exception.excel.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.ErrorCode;
+
+public enum ExcelErrorCode implements ErrorCode {
+	INVALID_INPUT_VALUE("EXCEL-001", "유효하지 않은 입력입니다.", HttpStatus.BAD_REQUEST),
+	INVALID_PREFERRED_REGION("EXCEL-002", "유효하지 않은 희망 지역 입력입니다.", HttpStatus.BAD_REQUEST),
+	DUPLICATED_CUSTOMER("EXCEL-002", "중복된 고객이 존재합니다.", HttpStatus.BAD_REQUEST),
+	;
+
+	private final String code;
+	private final String message;
+	private final HttpStatus status;
+
+	ExcelErrorCode(String code, String message, HttpStatus status) {
+		this.code = code;
+		this.message = message;
+		this.status = status;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/exception/external/ExternalException.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/external/ExternalException.java
@@ -1,0 +1,11 @@
+package com.zipline.global.exception.external;
+
+import com.zipline.global.exception.BaseException;
+import com.zipline.global.exception.ErrorCode;
+
+public class ExternalException extends BaseException {
+
+	public ExternalException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/exception/external/errorcode/ExternalErrorCode.java
+++ b/apiserver/common/src/main/java/com/zipline/global/exception/external/errorcode/ExternalErrorCode.java
@@ -1,0 +1,35 @@
+package com.zipline.global.exception.external.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import com.zipline.global.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum ExternalErrorCode implements ErrorCode {
+	KAKAO_CLIENT_ERROR("EXTERNAL_001", "카카오 API 클라이언트 오류", HttpStatus.BAD_REQUEST),
+	KAKAO_INVALID_API_KEY("EXTERNAL_002", "카카오 API 인증 실패", HttpStatus.UNAUTHORIZED),
+	KAKAO_SERVER_ERROR("EXTERNAL_003", "카카오 API 서버 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+	KAKAO_CONNECTION_FAIL("EXTERNAL_004", "카카오 API 통신 실패", HttpStatus.BAD_GATEWAY),
+	KAKAO_UNKNOWN_ERROR("EXTERNAL_005", "카카오 API 호출 중 알 수 없는 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus status;
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/apiserver/common/src/main/java/com/zipline/global/response/ExceptionResponseDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/response/ExceptionResponseDTO.java
@@ -1,7 +1,10 @@
 package com.zipline.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Getter;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 public class ExceptionResponseDTO<T> {
 	private String code;

--- a/apiserver/common/src/main/java/com/zipline/global/response/ExceptionResponseDTO.java
+++ b/apiserver/common/src/main/java/com/zipline/global/response/ExceptionResponseDTO.java
@@ -3,16 +3,22 @@ package com.zipline.global.response;
 import lombok.Getter;
 
 @Getter
-public class ExceptionResponseDTO {
+public class ExceptionResponseDTO<T> {
 	private String code;
 	private String message;
+	private T errors;
 
-	private ExceptionResponseDTO(String code, String message) {
+	private ExceptionResponseDTO(String code, String message, T errors) {
 		this.code = code;
 		this.message = message;
+		this.errors = errors;
 	}
 
 	public static ExceptionResponseDTO of(String code, String message) {
-		return new ExceptionResponseDTO(code, message);
+		return new ExceptionResponseDTO(code, message, null);
+	}
+
+	public static <T> ExceptionResponseDTO of(String code, String message, T errors) {
+		return new ExceptionResponseDTO(code, message, errors);
 	}
 }

--- a/apiserver/common/src/main/java/com/zipline/global/util/ExcelParser.java
+++ b/apiserver/common/src/main/java/com/zipline/global/util/ExcelParser.java
@@ -1,0 +1,93 @@
+package com.zipline.global.util;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.zipline.global.exception.excel.ExcelException;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+
+@Component
+public class ExcelParser {
+
+	private ExcelParser() {
+	}
+
+	public static String formatPhone(String value) {
+		if (value == null)
+			return null;
+		String digits = value.replaceAll("\\D", ""); // 숫자만 추출
+
+		if (digits.length() == 11) {
+			return digits.replaceFirst("(\\d{3})(\\d{4})(\\d{4})", "$1-$2-$3");
+		} else if (digits.length() == 10) {
+			return digits.replaceFirst("(\\d{3})(\\d{3})(\\d{4})", "$1-$2-$3");
+		} else {
+			return value;
+		}
+	}
+
+	public static String getCell(Row row, int idx, DataFormatter formatter) {
+		Cell cell = row.getCell(idx);
+		if (cell == null)
+			return null;
+		String value = formatter.formatCellValue(cell);
+		return StringUtils.hasText(value) ? value.trim() : null;
+	}
+
+	public static BigInteger parseBigInt(String value) {
+		if (!StringUtils.hasText(value))
+			return null;
+		return new BigInteger(value.replaceAll(",", ""));
+	}
+
+	public static boolean parsePrimitiveBoolean(String value) {
+		return "Y".equalsIgnoreCase(value) || "TRUE".equalsIgnoreCase(value) || "O".equalsIgnoreCase(value);
+	}
+
+	public static Boolean parseReferneceBoolean(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return null;
+		}
+
+		if ("Y".equalsIgnoreCase(value) || "TRUE".equalsIgnoreCase(value) || "O".equalsIgnoreCase(value)) {
+			return true;
+		}
+
+		if ("N".equalsIgnoreCase(value) || "NO".equalsIgnoreCase(value) || "FALSE".equalsIgnoreCase(value)) {
+			return false;
+		}
+		return null;
+	}
+
+	public static LocalDate parseDate(int rowNum, String filedName, String value) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		try {
+			return LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+		} catch (DateTimeParseException e) {
+			throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, filedName, value,
+				"날짜는 YYYY-MM-DD 형식이어야 합니다.");
+		}
+	}
+
+	public static Integer parseInteger(String value) {
+		if (!StringUtils.hasText(value))
+			return null;
+		return Integer.parseInt(value.replaceAll("\\D", ""));
+	}
+
+	public static Double parseDouble(String value) {
+		if (!StringUtils.hasText(value))
+			return null;
+		return Double.parseDouble(value.replaceAll(",", ""));
+	}
+}

--- a/apiserver/controller/src/main/java/com/zipline/controller/agentProperty/AgentPropertyController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/agentProperty/AgentPropertyController.java
@@ -2,6 +2,7 @@ package com.zipline.controller.agentProperty;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.global.request.AgentPropertyFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
@@ -27,6 +30,7 @@ import com.zipline.service.contract.dto.response.ContractPropertyHistoryResponse
 import com.zipline.service.contract.dto.response.ContractPropertyResponseDTO;
 import com.zipline.service.counsel.CounselService;
 import com.zipline.service.counsel.dto.response.CounselPageResponseDTO;
+import com.zipline.service.excel.ExcelService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -40,6 +44,7 @@ public class AgentPropertyController {
 
 	private final AgentPropertyService agentPropertyService;
 	private final CounselService counselService;
+	private final ExcelService excelService;
 	private final ContractService contractService;
 
 	@GetMapping("/{propertyUid}")
@@ -116,5 +121,15 @@ public class AgentPropertyController {
 			propertyUid, Long.parseLong(principal.getName()));
 		ApiResponse<List<ContractPropertyHistoryResponseDTO>> response = ApiResponse.ok("계약 히스토리 정보 조회 성공", result);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	@PostMapping("/bulk")
+	public ResponseEntity<ApiResponse<?>> registerPropertiesByExcel(
+		@RequestPart(required = false) MultipartFile file,
+		Principal principal) {
+		Map<String, Integer> result = excelService.registerPropertiesByExcel(file,
+			Long.parseLong(principal.getName()));
+		ApiResponse<Map<String, Integer>> response = ApiResponse.create("매물 엑셀 등록에 성공하였습니다.", result);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
+++ b/apiserver/controller/src/main/java/com/zipline/controller/customer/CustomerController.java
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.zipline.global.request.CustomerFilterRequestDTO;
 import com.zipline.global.request.PageRequestDTO;
@@ -29,6 +31,7 @@ import com.zipline.service.customer.dto.request.CustomerModifyRequestDTO;
 import com.zipline.service.customer.dto.request.CustomerRegisterRequestDTO;
 import com.zipline.service.customer.dto.response.CustomerDetailResponseDTO;
 import com.zipline.service.customer.dto.response.CustomerListResponseDTO;
+import com.zipline.service.excel.ExcelService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,7 @@ public class CustomerController {
 
 	private final CustomerService customerService;
 	private final CounselService counselService;
+	private final ExcelService excelService;
 
 	@GetMapping("/customers")
 	public ResponseEntity<ApiResponse<CustomerListResponseDTO>> getCustomers(
@@ -102,7 +106,6 @@ public class CustomerController {
 	@PutMapping("/customers/{customerUid}")
 	public ResponseEntity<ApiResponse<CustomerDetailResponseDTO>> modifyCustomer(@PathVariable Long customerUid,
 		@Valid @RequestBody CustomerModifyRequestDTO customerModifyRequestDTO, Principal principal) {
-
 		CustomerDetailResponseDTO result = customerService.modifyCustomer(
 			customerUid, customerModifyRequestDTO, Long.parseLong(principal.getName()));
 		ApiResponse<CustomerDetailResponseDTO> response = ApiResponse.ok("고객 수정에 성공하였습니다.", result);
@@ -122,6 +125,15 @@ public class CustomerController {
 		Map<String, Long> result = counselService.createCounsel(customerUid, requestDTO,
 			Long.parseLong(principal.getName()));
 		ApiResponse<Map<String, Long>> response = ApiResponse.create("상담 생성에 성공하였습니다.", result);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@PostMapping("/customers/bulk")
+	public ResponseEntity<ApiResponse<Map<String, Integer>>> registerCustomerByExcel(@RequestPart MultipartFile file,
+		Principal principal) {
+		Map<String, Integer> result = excelService.registerCustomerByExcel(file,
+			Long.parseLong(principal.getName()));
+		ApiResponse<Map<String, Integer>> response = ApiResponse.create("고객 엑셀 등록 성공", result);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/apiserver/controller/src/main/resources/application-dev.yml
+++ b/apiserver/controller/src/main/resources/application-dev.yml
@@ -66,3 +66,7 @@ file:
 cache:
   keys:
     children-regions-prefix: ${CACHE_KEY_CHILDREN_REGIONS_PREFIX}
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}

--- a/apiserver/controller/src/main/resources/application-test.yml
+++ b/apiserver/controller/src/main/resources/application-test.yml
@@ -66,3 +66,7 @@ file:
 cache:
   keys:
     children-regions-prefix: ${CACHE_KEY_CHILDREN_REGIONS_PREFIX}
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}

--- a/apiserver/domain/src/main/java/com/zipline/entity/customer/Customer.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/customer/Customer.java
@@ -21,6 +21,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "customers")
+@Table(name = "customers", uniqueConstraints = {
+	@UniqueConstraint(name = "name_phone_unique", columnNames = {"name", "phone_no"})})
 @Entity
 public class Customer extends BaseTimeEntity {
 

--- a/apiserver/infrastructure/build.gradle
+++ b/apiserver/infrastructure/build.gradle
@@ -8,6 +8,12 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    implementation "org.apache.poi:poi:5.2.3"
+    implementation "org.apache.poi:poi-ooxml:5.2.3"
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+
+    implementation "org.springframework:spring-web"
 }
 
 bootJar {

--- a/apiserver/infrastructure/src/main/java/com/zipline/api/GeoCodeResultVO.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/api/GeoCodeResultVO.java
@@ -1,0 +1,12 @@
+package com.zipline.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeoCodeResultVO {
+	private String legalDistrictCode;
+	private String longitude;
+	private String latitude;
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/api/KakaoGeoClient.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/api/KakaoGeoClient.java
@@ -1,0 +1,74 @@
+package com.zipline.api;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.zipline.global.exception.external.ExternalException;
+import com.zipline.global.exception.external.errorcode.ExternalErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KakaoGeoClient {
+
+	private static final String KAKAO_GEOCODE_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+	private final RestTemplate restTemplate;
+
+	@Value("${kakao.api.key}")
+	private String apiKey;
+
+	public KakaoGeocodeResponseDTO getCoordinatesByAddress(String address) {
+		URI uri = UriComponentsBuilder.fromUriString(KAKAO_GEOCODE_URL)
+			.queryParam("query", address)
+			.build()
+			.encode(StandardCharsets.UTF_8)
+			.toUri();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "KakaoAK " + apiKey);
+		HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+		log.debug("[Kakao API URI] {}", uri);
+
+		try {
+			ResponseEntity<KakaoGeocodeResponseDTO> response = restTemplate.exchange(
+				uri, HttpMethod.GET, entity, KakaoGeocodeResponseDTO.class);
+
+			return response.getBody();
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+				log.error("[Kakao API 401 인증 오류] API Key 확인 필요. uri={}", uri);
+				throw new ExternalException(ExternalErrorCode.KAKAO_INVALID_API_KEY);
+			}
+			log.error("[Kakao API 4xx 오류] status={}, uri={}", e.getStatusCode(), uri);
+			throw new ExternalException(ExternalErrorCode.KAKAO_CLIENT_ERROR);
+		} catch (HttpServerErrorException e) {
+			log.error("[Kakao API 5xx 서버 오류] status={}, uri={}", e.getStatusCode(), uri);
+			throw new ExternalException(ExternalErrorCode.KAKAO_SERVER_ERROR);
+		} catch (ResourceAccessException e) {
+			log.error("[Kakao API 연결 실패] {}", e.getMessage());
+			throw new ExternalException(ExternalErrorCode.KAKAO_CONNECTION_FAIL);
+		} catch (RestClientException e) {
+			log.error("[Kakao API 기타 오류] {}", e.getMessage(), e);
+			throw new ExternalException(ExternalErrorCode.KAKAO_UNKNOWN_ERROR);
+		}
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/api/KakaoGeocodeResponseDTO.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/api/KakaoGeocodeResponseDTO.java
@@ -1,0 +1,41 @@
+package com.zipline.api;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoGeocodeResponseDTO {
+
+	private List<Document> documents;
+
+	@Getter
+	public static class Document {
+		@JsonProperty("x")
+		private String longitude;
+		@JsonProperty("y")
+		private String latitude;
+
+		@JsonProperty("address")
+		private Address address;
+
+		@JsonProperty("road_address")
+		private RoadAddress roadAddress;
+
+		@Getter
+		public static class Address {
+			@JsonProperty("address_name")
+			private String jibunAddressName;
+			@JsonProperty("b_code")
+			private String legalDistrictCode;
+		}
+
+		@Getter
+		public static class RoadAddress {
+			@JsonProperty("address_name")
+			private String roadAddressName;
+		}
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/AgentPropertyExcelDTO.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/AgentPropertyExcelDTO.java
@@ -1,0 +1,105 @@
+package com.zipline.excel;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+import org.springframework.util.StringUtils;
+
+import com.zipline.global.exception.excel.ExcelException;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class AgentPropertyExcelDTO {
+	private Integer rowNum;
+	private String customerName;
+	private String phoneNo;
+	private String roadName;
+	private String detailAddress;
+	private String realCategory;
+	private String type;
+	private BigInteger deposit;
+	private BigInteger monthlyRent;
+	private BigInteger price;
+	private LocalDate startDate;
+	private LocalDate endDate;
+	private LocalDate moveInDate;
+	private Boolean petsAllowed;
+	private Integer floor;
+	private Boolean hasElevator;
+	private String constructionYear;
+	private Double parkingCapacity;
+	private Double netArea;
+	private Double totalArea;
+	private String details;
+
+	public AgentPropertyExcelDTO(Integer rowNum, String customerName, String phoneNo, String roadName,
+		String detailAddress,
+		String realCategory, String type,
+		BigInteger deposit, BigInteger monthlyRent, BigInteger price, LocalDate startDate, LocalDate endDate,
+		LocalDate moveInDate, Boolean petsAllowed, Integer floor, Boolean hasElevator, String constructionYear,
+		Double parkingCapacity, Double netArea, Double totalArea, String details) {
+		this.rowNum = rowNum;
+		this.customerName = customerName;
+		this.phoneNo = phoneNo;
+		this.roadName = roadName;
+		this.detailAddress = detailAddress;
+		this.realCategory = realCategory;
+		this.type = type;
+		this.deposit = deposit;
+		this.monthlyRent = monthlyRent;
+		this.price = price;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.moveInDate = moveInDate;
+		this.petsAllowed = petsAllowed;
+		this.floor = floor;
+		this.hasElevator = hasElevator;
+		this.constructionYear = constructionYear;
+		this.parkingCapacity = parkingCapacity;
+		this.netArea = netArea;
+		this.totalArea = totalArea;
+		this.details = details;
+	}
+
+	public void validate() {
+		if (!StringUtils.hasText(customerName)) {
+			throwValidation("customerName", customerName, "이름은 필수입니다.");
+		}
+		if (!StringUtils.hasText(phoneNo) || !phoneNo.matches("^(\\d{3})-(\\d{3,4})-(\\d{4})$")) {
+			throwValidation("phoneNo", phoneNo, "전화번호 형식이 올바르지 않습니다.");
+		}
+		if (!StringUtils.hasText(roadName)) {
+			throwValidation("address", roadName, "주소는 필수입니다.");
+		}
+		if (!StringUtils.hasText(realCategory)) {
+			throwValidation("realCategory", realCategory, "유형(카테고리)은 필수입니다.");
+		}
+		if (!StringUtils.hasText(type)) {
+			throwValidation("type", type, "매물 타입은 필수입니다.");
+		}
+		if (netArea == null) {
+			throwValidation("netArea", "null", "전용 면적은 필수입니다.");
+		}
+		if (totalArea == null) {
+			throwValidation("totalArea", "null", "공급 면적은 필수입니다.");
+		}
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throwValidation("startDate/endDate", startDate + "/" + endDate, "계약 시작일은 계약 종료일보다 미래일 수 없습니다.");
+		}
+		if (petsAllowed == null) {
+			throwValidation("petsAllowed", "null", "반려동물 허용 여부는 필수입니다.");
+		}
+		if (hasElevator == null) {
+			throwValidation("hasElevator", "null", "엘리베이터 여부는 필수입니다.");
+		}
+		if (StringUtils.hasText(details) && details.length() > 255) {
+			throwValidation("details", details, "세부 사항의 최대 길이는 255자 입니다.");
+		}
+	}
+
+	private void throwValidation(String field, Object value, String message) {
+		throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, field, value, message);
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/AgentPropertyExcelRowMapper.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/AgentPropertyExcelRowMapper.java
@@ -1,0 +1,85 @@
+package com.zipline.excel;
+
+import static com.zipline.global.util.ExcelParser.*;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.springframework.stereotype.Component;
+
+import com.zipline.global.exception.excel.ExcelException;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+
+@Component
+public class AgentPropertyExcelRowMapper implements ExcelRowMapper<AgentPropertyExcelDTO> {
+
+	@Override
+	public AgentPropertyExcelDTO map(Row row, DataFormatter formatter) {
+		Integer rowNum = row.getRowNum();
+		String customerName = getCell(row, 0, formatter);
+		String phoneNo = formatPhone(getCell(row, 1, formatter));
+		String roadName = getCell(row, 2, formatter);
+		String detailAddress = getCell(row, 3, formatter);
+		String realCategory = convertRealCategoryFromKorean(rowNum, getCell(row, 4, formatter));
+		String type = convertPropertyTypeFromKorean(rowNum, getCell(row, 5, formatter));
+		BigInteger deposit = parseBigInt(getCell(row, 6, formatter));
+		BigInteger monthlyRent = parseBigInt(getCell(row, 7, formatter));
+		BigInteger price = parseBigInt(getCell(row, 8, formatter));
+		LocalDate startDate = parseDate(rowNum, "계약 시작일", getCell(row, 9, formatter));
+		LocalDate endDate = parseDate(rowNum, "계약 종료일", getCell(row, 10, formatter));
+		LocalDate moveInDate = parseDate(rowNum, "입주 가능일", getCell(row, 11, formatter));
+		Boolean petsAllowed = parseReferneceBoolean(getCell(row, 12, formatter));
+		Integer floor = parseInteger(getCell(row, 13, formatter));
+		Boolean hasElevator = parseReferneceBoolean(getCell(row, 14, formatter));
+		String constructionYear = getCell(row, 15, formatter);
+		Double parkingCapacity = parseDouble(getCell(row, 16, formatter));
+		Double netArea = parseDouble(getCell(row, 17, formatter));
+		Double totalArea = parseDouble(getCell(row, 18, formatter));
+		String details = getCell(row, 19, formatter);
+
+		AgentPropertyExcelDTO dto = new AgentPropertyExcelDTO(rowNum, customerName, phoneNo, roadName, detailAddress,
+			realCategory, type, deposit, monthlyRent, price, startDate, endDate, moveInDate, petsAllowed, floor,
+			hasElevator, constructionYear, parkingCapacity, netArea, totalArea, details
+		);
+		dto.validate();
+		return dto;
+	}
+
+	private String convertPropertyTypeFromKorean(int rowNum, String type) {
+		switch (type) {
+			case "매매":
+				return "SALE";
+			case "전세":
+				return "DEPOSIT";
+			case "월세":
+				return "MONTHLY";
+			default:
+				throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, "Property Type", type,
+					"잘못된 매물 유형입니다.");
+		}
+	}
+
+	private String convertRealCategoryFromKorean(int rowNum, String realCategory) {
+		switch (realCategory) {
+			case "원룸":
+				return "ONE_ROOM";
+			case "투룸":
+				return "TWO_ROOM";
+			case "아파트":
+				return "APARTMENT";
+			case "빌라":
+				return "VILLA";
+			case "주택":
+				return "HOUSE";
+			case "오피스텔":
+				return "OFFICETEL";
+			case "상가":
+				return "COMMERCIAL";
+			default:
+				throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, "Property Category", realCategory,
+					"잘못된 매물 카테고리입니다.");
+		}
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/CustomerExcelDTO.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/CustomerExcelDTO.java
@@ -1,0 +1,91 @@
+package com.zipline.excel;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.springframework.util.StringUtils;
+
+import com.zipline.global.exception.excel.ExcelException;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class CustomerExcelDTO {
+	private Integer rowNum;
+	private String name;
+	private String phoneNo;
+	private String telProvider;
+	private String preferredRegion;
+	private boolean landlord;
+	private boolean tenant;
+	private boolean buyer;
+	private boolean seller;
+	private BigInteger minRent;
+	private BigInteger maxRent;
+	private BigInteger maxPrice;
+	private BigInteger minPrice;
+	private BigInteger minDeposit;
+	private BigInteger maxDeposit;
+	private String birthDay;
+
+	public CustomerExcelDTO(Integer rowNum, String name, String phoneNo, String telProvider, String preferredRegion,
+		boolean landlord, boolean tenant, boolean buyer, boolean seller, BigInteger minRent, BigInteger maxRent,
+		BigInteger maxPrice, BigInteger minPrice, BigInteger minDeposit, BigInteger maxDeposit, String birthDay) {
+		this.rowNum = rowNum;
+		this.name = name;
+		this.phoneNo = phoneNo;
+		this.telProvider = telProvider;
+		this.preferredRegion = preferredRegion;
+		this.landlord = landlord;
+		this.tenant = tenant;
+		this.buyer = buyer;
+		this.seller = seller;
+		this.minRent = minRent;
+		this.maxRent = maxRent;
+		this.maxPrice = maxPrice;
+		this.minPrice = minPrice;
+		this.minDeposit = minDeposit;
+		this.maxDeposit = maxDeposit;
+		this.birthDay = birthDay;
+	}
+
+	public void validate() {
+		if (!StringUtils.hasText(name)) {
+			throwValidation("name", name, "이름은 필수입니다.");
+		}
+
+		if (!phoneNo.matches("^(\\d{3})-(\\d{3,4})-(\\d{4})$")) {
+			throwValidation("phoneNo", phoneNo, "전화번호 형식이 올바르지 않습니다.");
+		}
+
+		if (minRent != null && maxRent != null && minRent.compareTo(maxRent) > 0) {
+			throwValidation("minRent/maxRent", minRent + "/" + maxRent, "최소 월세는 최대 월세보다 작거나 같아야 합니다.");
+		}
+
+		if (minPrice != null && maxPrice != null && minPrice.compareTo(maxPrice) > 0) {
+			throwValidation("minPrice/maxPrice", minPrice + "/" + maxPrice, "최소 매매가는 최대 매매가보다 작거나 같아야 합니다.");
+		}
+
+		if (minDeposit != null && maxDeposit != null && minDeposit.compareTo(maxDeposit) > 0) {
+			throwValidation("minDeposit/maxDeposit", minDeposit + "/" + maxDeposit, "최소 보증금은 최대 보증금보다 작거나 같아야 합니다.");
+		}
+
+		if (StringUtils.hasText(birthDay)) {
+			try {
+				LocalDate birth = LocalDate.parse(birthDay, DateTimeFormatter.ofPattern("yyyyMMdd"));
+				if (birth.isAfter(LocalDate.now())) {
+					throwValidation("birthDay", birthDay, "생년월일은 미래일 수 없습니다.");
+				}
+			} catch (DateTimeParseException e) {
+				throwValidation("birthDay", birthDay, "생년월일 형식은 yyyyMMdd 입니다.");
+			}
+		}
+	}
+
+	private void throwValidation(String field, Object value, String message) {
+		throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, field, value, message);
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/CustomerExcelRowMapper.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/CustomerExcelRowMapper.java
@@ -1,0 +1,54 @@
+package com.zipline.excel;
+
+import static com.zipline.global.util.ExcelParser.*;
+
+import java.math.BigInteger;
+
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomerExcelRowMapper implements ExcelRowMapper<CustomerExcelDTO> {
+
+	@Override
+	public CustomerExcelDTO map(Row row, DataFormatter formatter) {
+		Integer rowNum = row.getRowNum();
+		String name = getCell(row, 0, formatter);
+		String phoneNo = formatPhone(getCell(row, 1, formatter));
+		String telProvider = getCell(row, 2, formatter);
+		String preferredRegion = getCell(row, 3, formatter);
+		boolean landlord = parsePrimitiveBoolean(getCell(row, 4, formatter));
+		boolean tenant = parsePrimitiveBoolean(getCell(row, 5, formatter));
+		boolean buyer = parsePrimitiveBoolean(getCell(row, 6, formatter));
+		boolean seller = parsePrimitiveBoolean(getCell(row, 7, formatter));
+		BigInteger minRent = parseBigInt(getCell(row, 8, formatter));
+		BigInteger maxRent = parseBigInt(getCell(row, 9, formatter));
+		BigInteger minPrice = parseBigInt(getCell(row, 10, formatter));
+		BigInteger maxPrice = parseBigInt(getCell(row, 11, formatter));
+		BigInteger minDeposit = parseBigInt(getCell(row, 12, formatter));
+		BigInteger maxDeposit = parseBigInt(getCell(row, 13, formatter));
+		String birthDay = getCell(row, 14, formatter);
+
+		CustomerExcelDTO dto = new CustomerExcelDTO(
+			rowNum,
+			name,
+			phoneNo,
+			telProvider,
+			preferredRegion,
+			landlord,
+			tenant,
+			buyer,
+			seller,
+			minRent,
+			maxRent,
+			maxPrice,
+			minPrice,
+			minDeposit,
+			maxDeposit,
+			birthDay
+		);
+		dto.validate();
+		return dto;
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/ExcelReader.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/ExcelReader.java
@@ -1,0 +1,42 @@
+package com.zipline.excel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.zipline.global.exception.common.FileUploadException;
+import com.zipline.global.exception.common.errorcode.CommonErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class ExcelReader {
+
+	public <T> List<T> readExcel(MultipartFile inputStream, ExcelRowMapper<T> mapper) {
+		try (InputStream is = inputStream.getInputStream()) {
+			XSSFWorkbook workbook = new XSSFWorkbook(is);
+			XSSFSheet sheet = workbook.getSheetAt(0);
+			DataFormatter formatter = new DataFormatter();
+
+			List<T> list = new ArrayList<>();
+			for (int i = 1; i < sheet.getPhysicalNumberOfRows(); i++) {
+				Row row = sheet.getRow(i);
+				if (row != null) {
+					list.add(mapper.map(row, formatter));
+				}
+			}
+			return list;
+		} catch (IOException e) {
+			throw new FileUploadException(CommonErrorCode.FILE_UPLOAD_FAILED);
+		}
+	}
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/excel/ExcelRowMapper.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/excel/ExcelRowMapper.java
@@ -1,0 +1,8 @@
+package com.zipline.excel;
+
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+
+public interface ExcelRowMapper<T> {
+	T map(Row row, DataFormatter formatter);
+}

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
@@ -3,8 +3,6 @@ package com.zipline.repository.customer;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -23,11 +21,4 @@ public interface CustomerRepository extends JpaRepository<Customer, Long>, QCust
 		"AND SUBSTRING(c.birthday, 5) = :mmdd " +
 		"AND c.deletedAt IS NULL")
 	List<Customer> findCustomersWithBirthdayToday(Long userUid, String mmdd);
-
-	@Query(value = "SELECT DISTINCT c FROM Customer c " +
-		"LEFT JOIN FETCH c.labelCustomers lc " +
-		"LEFT JOIN FETCH lc.label " +
-		"WHERE c.user.uid = :userUid AND c.deletedAt IS NULL",
-		countQuery = "SELECT COUNT(c) FROM Customer c WHERE c.user.uid = :userUid AND c.deletedAt IS NULL")
-	Page<Customer> findByUserUidWithLabels(Long userUid, Pageable pageable);
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/CustomerRepository.java
@@ -1,11 +1,15 @@
 package com.zipline.repository.customer;
 
-import com.zipline.entity.customer.Customer;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import com.zipline.entity.customer.Customer;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long>, QCustomerRepository {
@@ -16,7 +20,14 @@ public interface CustomerRepository extends JpaRepository<Customer, Long>, QCust
 	Optional<Customer> findByUidAndUserUidAndDeletedAtIsNull(Long customerUid, Long userUid);
 
 	@Query("SELECT c FROM Customer c WHERE c.user.uid = :userUid " +
-			"AND SUBSTRING(c.birthday, 5) = :mmdd " +
-			"AND c.deletedAt IS NULL")
+		"AND SUBSTRING(c.birthday, 5) = :mmdd " +
+		"AND c.deletedAt IS NULL")
 	List<Customer> findCustomersWithBirthdayToday(Long userUid, String mmdd);
+
+	@Query(value = "SELECT DISTINCT c FROM Customer c " +
+		"LEFT JOIN FETCH c.labelCustomers lc " +
+		"LEFT JOIN FETCH lc.label " +
+		"WHERE c.user.uid = :userUid AND c.deletedAt IS NULL",
+		countQuery = "SELECT COUNT(c) FROM Customer c WHERE c.user.uid = :userUid AND c.deletedAt IS NULL")
+	Page<Customer> findByUserUidWithLabels(Long userUid, Pageable pageable);
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepository.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepository.java
@@ -1,5 +1,8 @@
 package com.zipline.repository.customer;
 
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +13,6 @@ public interface QCustomerRepository {
 	Page<Customer> findByUserUidAndDeletedAtIsNullWithFilters(Long userUid,
 		CustomerFilterRequestDTO customerFilterRequestDTO,
 		Pageable pageable);
+
+	List<Customer> findByNameAndPhoneNoPairs(Set<String> keySet);
 }

--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepositoryImpl.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.zipline.entity.customer.QCustomer.*;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,8 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zipline.entity.customer.Customer;
@@ -72,6 +75,17 @@ public class QCustomerRepositoryImpl implements QCustomerRepository {
 			);
 
 		return PageableExecutionUtils.getPage(result, pageable, totalCount::fetchOne);
+	}
+
+	@Override
+	public List<Customer> findByNameAndPhoneNoPairs(Set<String> keySet) {
+		StringExpression keyExpr = Expressions.stringTemplate(
+			"concat({0}, ',', {1})", customer.name, customer.phoneNo);
+
+		return queryFactory
+			.selectFrom(customer)
+			.where(keyExpr.in(keySet))
+			.fetch();
 	}
 
 	private BooleanExpression userUidEq(Long userUid) {

--- a/apiserver/service/src/main/java/com/zipline/service/excel/ExcelService.java
+++ b/apiserver/service/src/main/java/com/zipline/service/excel/ExcelService.java
@@ -1,0 +1,12 @@
+package com.zipline.service.excel;
+
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ExcelService {
+
+	Map<String, Integer> registerCustomerByExcel(MultipartFile file, Long userUid);
+
+	Map<String, Integer> registerPropertiesByExcel(MultipartFile multipartFile, Long userUid);
+}

--- a/apiserver/service/src/main/java/com/zipline/service/excel/ExcelServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/excel/ExcelServiceImpl.java
@@ -1,0 +1,238 @@
+package com.zipline.service.excel;
+
+import java.time.Year;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.zipline.api.GeoCodeResultVO;
+import com.zipline.api.KakaoGeoClient;
+import com.zipline.api.KakaoGeocodeResponseDTO;
+import com.zipline.entity.agentProperty.AgentProperty;
+import com.zipline.entity.customer.Customer;
+import com.zipline.entity.enums.PropertyCategory;
+import com.zipline.entity.enums.PropertyType;
+import com.zipline.entity.user.User;
+import com.zipline.excel.AgentPropertyExcelDTO;
+import com.zipline.excel.AgentPropertyExcelRowMapper;
+import com.zipline.excel.CustomerExcelDTO;
+import com.zipline.excel.CustomerExcelRowMapper;
+import com.zipline.excel.ExcelReader;
+import com.zipline.global.exception.excel.ExcelException;
+import com.zipline.global.exception.excel.errorcode.ExcelErrorCode;
+import com.zipline.global.exception.user.UserException;
+import com.zipline.global.exception.user.errorcode.UserErrorCode;
+import com.zipline.repository.agentProperty.AgentPropertyRepository;
+import com.zipline.repository.customer.CustomerRepository;
+import com.zipline.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ExcelServiceImpl implements ExcelService {
+
+	private final ExcelReader excelReader;
+	private final CustomerExcelRowMapper customerExcelRowMapper;
+	private final AgentPropertyExcelRowMapper agentPropertyExcelRowMapper;
+	private final KakaoGeoClient kakaoGeoClient;
+	private final UserRepository userRepository;
+	private final CustomerRepository customerRepository;
+	private final AgentPropertyRepository agentPropertyRepository;
+
+	@Override
+	@Transactional
+	public Map<String, Integer> registerCustomerByExcel(MultipartFile excelFile, Long userUid) {
+		List<CustomerExcelDTO> dtoList = readCustomerExcel(excelFile);
+		checkCustomerDuplicateInExcel(dtoList);
+		User user = getUserOrThrow(userUid);
+		checkCustomerDuplicateInDB(dtoList);
+		List<Customer> customers = mapToCustomerEntities(dtoList, user);
+		customerRepository.saveAll(customers);
+		return Collections.singletonMap("success Count", customers.size());
+	}
+
+	@Override
+	@Transactional
+	public Map<String, Integer> registerPropertiesByExcel(MultipartFile excelFile, Long userUid) {
+		List<AgentPropertyExcelDTO> dtoList = readPropertyExcel(excelFile);
+		User user = getUserOrThrow(userUid);
+		Map<String, Customer> customerMap = prepareCustomersForProperty(dtoList, user);
+		List<AgentProperty> properties = mapToAgentProperties(dtoList, customerMap, user);
+		agentPropertyRepository.saveAll(properties);
+		return Collections.singletonMap("success Count", properties.size());
+	}
+
+	private List<CustomerExcelDTO> readCustomerExcel(MultipartFile file) {
+		return excelReader.readExcel(file, customerExcelRowMapper);
+	}
+
+	private List<AgentPropertyExcelDTO> readPropertyExcel(MultipartFile file) {
+		return excelReader.readExcel(file, agentPropertyExcelRowMapper);
+	}
+
+	private void checkCustomerDuplicateInExcel(List<CustomerExcelDTO> list) {
+		Set<String> uniqueKeySet = new HashSet<>();
+		for (CustomerExcelDTO dto : list) {
+			String key = dto.getName() + "," + dto.getPhoneNo();
+			if (!uniqueKeySet.add(key)) {
+				throw new ExcelException(ExcelErrorCode.DUPLICATED_CUSTOMER, dto.getRowNum(), "name/phoneNo", key,
+					"엑셀에 중복된 고객이 존재합니다.");
+			}
+		}
+	}
+
+	private void checkCustomerDuplicateInDB(List<CustomerExcelDTO> list) {
+		Set<String> keySet = list.stream()
+			.map(dto -> dto.getName() + "," + dto.getPhoneNo())
+			.collect(Collectors.toSet());
+		List<Customer> exists = customerRepository.findByNameAndPhoneNoPairs(keySet);
+		if (!exists.isEmpty()) {
+			Map<String, Integer> rowNumMap = list.stream()
+				.collect(Collectors.toMap(dto -> dto.getName() + "," + dto.getPhoneNo(), CustomerExcelDTO::getRowNum));
+			throw new ExcelException(ExcelErrorCode.DUPLICATED_CUSTOMER,
+				convertToDuplicatedCustomerDetails(exists, rowNumMap));
+		}
+	}
+
+	private List<Customer> mapToCustomerEntities(List<CustomerExcelDTO> list, User user) {
+		return list.stream().map(dto -> {
+			String legalCode = resolveLegalDistrictCode(dto);
+			return toCustomerEntity(dto, legalCode, user);
+		}).toList();
+	}
+
+	private String resolveLegalDistrictCode(CustomerExcelDTO dto) {
+		if (dto.getPreferredRegion() == null)
+			return null;
+		GeoCodeResultVO geo = getGeoCode(dto.getRowNum(), dto.getPreferredRegion());
+		return geo.getLegalDistrictCode();
+	}
+
+	private Customer toCustomerEntity(CustomerExcelDTO dto, String legalCode, User user) {
+		return Customer.builder()
+			.user(user)
+			.name(dto.getName())
+			.phoneNo(dto.getPhoneNo())
+			.telProvider(dto.getTelProvider())
+			.legalDistrictCode(legalCode)
+			.minRent(dto.getMinRent()).maxRent(dto.getMaxRent())
+			.minDeposit(dto.getMinDeposit()).maxDeposit(dto.getMaxDeposit())
+			.minPrice(dto.getMinPrice()).maxPrice(dto.getMaxPrice())
+			.isBuyer(dto.isBuyer()).isSeller(dto.isSeller())
+			.isLandlord(dto.isLandlord()).isTenant(dto.isTenant())
+			.birthday(dto.getBirthDay())
+			.build();
+	}
+
+	private Map<String, Customer> prepareCustomersForProperty(List<AgentPropertyExcelDTO> list, User user) {
+		Set<String> keys = extractCustomerKeys(list);
+		Map<String, Customer> dbCustomers = findExistingCustomers(keys);
+		List<Customer> newCustomers = extractNewCustomers(list, keys, dbCustomers.keySet(), user);
+		customerRepository.saveAll(newCustomers);
+		newCustomers.forEach(c -> dbCustomers.put(c.getName() + "," + c.getPhoneNo(), c));
+		return dbCustomers;
+	}
+
+	private Set<String> extractCustomerKeys(List<AgentPropertyExcelDTO> list) {
+		return list.stream()
+			.map(dto -> dto.getCustomerName() + "," + dto.getPhoneNo())
+			.collect(Collectors.toSet());
+	}
+
+	private Map<String, Customer> findExistingCustomers(Set<String> keys) {
+		return customerRepository.findByNameAndPhoneNoPairs(keys).stream()
+			.collect(Collectors.toMap(c -> c.getName() + "," + c.getPhoneNo(), Function.identity()));
+	}
+
+	private List<Customer> extractNewCustomers(List<AgentPropertyExcelDTO> list, Set<String> allKeys,
+		Set<String> existingKeys, User user) {
+		return list.stream()
+			.map(dto -> Map.entry(dto.getCustomerName() + "," + dto.getPhoneNo(), dto))
+			.filter(entry -> !existingKeys.contains(entry.getKey()))
+			.distinct()
+			.map(entry -> Customer.builder()
+				.user(user)
+				.name(entry.getValue().getCustomerName())
+				.phoneNo(entry.getValue().getPhoneNo())
+				.build())
+			.toList();
+	}
+
+	private List<AgentProperty> mapToAgentProperties(List<AgentPropertyExcelDTO> list,
+		Map<String, Customer> customerMap, User user) {
+		return list.stream().map(dto -> {
+			GeoCodeResultVO geo = getGeoCode(dto.getRowNum(), dto.getRoadName());
+			Customer customer = customerMap.get(dto.getCustomerName() + "," + dto.getPhoneNo());
+			return AgentProperty.builder()
+				.customer(customer)
+				.user(user)
+				.address(dto.getRoadName())
+				.longitude(Double.valueOf(geo.getLongitude()))
+				.latitude(Double.valueOf(geo.getLatitude()))
+				.legalDistrictCode(geo.getLegalDistrictCode())
+				.constructionYear(Year.parse(dto.getConstructionYear()))
+				.floor(dto.getFloor())
+				.deposit(dto.getDeposit())
+				.monthlyRent(dto.getMonthlyRent())
+				.price(dto.getPrice())
+				.moveInDate(dto.getMoveInDate())
+				.startDate(dto.getStartDate())
+				.endDate(dto.getEndDate())
+				.petsAllowed(dto.getPetsAllowed())
+				.hasElevator(dto.getHasElevator())
+				.parkingCapacity(dto.getParkingCapacity())
+				.realCategory(PropertyCategory.valueOf(dto.getRealCategory()))
+				.type(PropertyType.valueOf(dto.getType()))
+				.totalArea(dto.getTotalArea())
+				.netArea(dto.getNetArea())
+				.details(dto.getDetails())
+				.build();
+		}).toList();
+	}
+
+	private GeoCodeResultVO getGeoCode(int rowNum, String roadName) {
+		log.info("[Kakao API 요청] rowNum={}, 주소={}", rowNum, roadName);
+		KakaoGeocodeResponseDTO response = kakaoGeoClient.getCoordinatesByAddress(roadName);
+		if (response == null || response.getDocuments().isEmpty()) {
+			log.warn("[Kakao API 실패] rowNum={}, 잘못된 주소 값", rowNum);
+			throw new ExcelException(ExcelErrorCode.INVALID_INPUT_VALUE, rowNum, "roadName", roadName,
+				"주소를 찾을 수 없습니다.");
+		}
+		KakaoGeocodeResponseDTO.Document first = response.getDocuments().get(0);
+		return new GeoCodeResultVO(
+			first.getAddress() != null ? first.getAddress().getLegalDistrictCode() : null,
+			first.getLongitude(),
+			first.getLatitude()
+		);
+	}
+
+	private User getUserOrThrow(Long userUid) {
+		return userRepository.findById(userUid)
+			.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+	}
+
+	private List<Map<String, Object>> convertToDuplicatedCustomerDetails(List<Customer> duplicatedCustomers,
+		Map<String, Integer> rowNumMap) {
+		return duplicatedCustomers.stream().map(customer -> {
+			String key = customer.getName() + "," + customer.getPhoneNo();
+			Map<String, Object> detail = new HashMap<>();
+			detail.put("rowNum", rowNumMap.getOrDefault(key, -1));
+			detail.put("field", "name/phoneNo");
+			detail.put("value", key);
+			detail.put("message", "이미 존재하는 고객입니다.");
+			return detail;
+		}).toList();
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #328 

## 📝작업 내용
> 고객 엑셀 파일 업로드 구현

- 고객 정보를 엑셀 파일로 받아 DB에 저장

- 기존 고객은 이름 + 전화번호를 기준으로 중복 검사

- 중복되면 등록하지 않음 (에러 응답 반환)

> 매물 엑셀 파일 업로드 구현
- 고객의 이름과 전화번호 + 매물 정보를 엑셀 파일로 받아 DB에 저장

- 기존 고객이 아닌 경우 고객 등록 후 매물과 매핑

> Kakao API 연동

- 주소 정보로 행정동 코드 및 위도/경도 좌표 조회

- 고객 및 매물 등록 시 해당 정보 함께 저장

> 예외 처리

- ExcelException, ExternalException 추가

- GlobalExceptionHandler에 Excel 및 외부 API 에러 처리 로직 반영

- 예외 응답 객체인 ExceptionResponseDTO에 errors 필드 추가

> RestTemplate 설정 클래스 추가 (Kakao API 통신용)