### PR TITLE
fix: 문자 템플릿 카테고리 수정 적용 안 되는 버그 수정

### DIFF
--- a/apiserver/domain/src/main/java/com/zipline/entity/message/MessageTemplate.java
+++ b/apiserver/domain/src/main/java/com/zipline/entity/message/MessageTemplate.java
@@ -32,7 +32,7 @@ public class MessageTemplate extends BaseTimeEntity {
   private User user;
 
   @Builder
-  public MessageTemplate(String name , MessageTemplateCategory category , String content,
+  public MessageTemplate(String name , MessageTemplateCategory category, String content,
     User user) {
     this.name = name;
     this.category = category;
@@ -40,8 +40,9 @@ public class MessageTemplate extends BaseTimeEntity {
     this.user = user;
   }
 
-  public void updateInfo(String name, String content) {
+  public void updateInfo(String name, MessageTemplateCategory category, String content) {
     this.name = name;
+    this.category = category;
     this.content = content;
   }
 }

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -72,7 +72,7 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 					});
 		}
 
-		messageTemplate.updateInfo(request.getName(), request.getContent());
+		messageTemplate.updateInfo(request.getName(), request.getCategory(), request.getContent());
 
 		return new MessageTemplateResponseDTO(messageTemplate);
 	}

--- a/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
+++ b/apiserver/service/src/main/java/com/zipline/service/message/MessageTemplateServiceImpl.java
@@ -71,6 +71,12 @@ public class MessageTemplateServiceImpl implements MessageTemplateService {
 						throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_NAME);
 					});
 		}
+		if (messageTemplate.getCategory().equals(MessageTemplateCategory.BIRTHDAY) || messageTemplate.getCategory().equals(MessageTemplateCategory.EXPIRED_NOTI)) {
+			messageTemplateRepository.findByCategoryAndUserUidAndDeletedAtIsNull(request.getCategory(), userUid)
+					.ifPresent(template -> {
+						throw new MessageTemplateException(MessageTemplateErrorCode.DUPLICATE_TEMPLATE_CATEGORY);
+					});
+		}
 
 		messageTemplate.updateInfo(request.getName(), request.getCategory(), request.getContent());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #378

## 📝작업 내용
* 버그 현상: 문자 템플릿 카테고리 수정이 적용되지 않음
* 버그 원인: 문자 템플릿 정보 업데이트 중 카테고리에 대한 업데이트 로직이 누락됨
* 버그 수정: 문자 템플릿 정보 업데이트 중 카테고리에 대한 업데이트 로직 추가

* 그 외 작업
  *  이미 존재하는 생일/계약 만료 문자 템플릿이 있다면 에러 리턴하도록 코드 추가


