### PR TITLE
fix: 법정동 코드 필터링 시 LIKE로 검색

### DIFF
--- a/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepositoryImpl.java
+++ b/apiserver/infrastructure/src/main/java/com/zipline/repository/customer/QCustomerRepositoryImpl.java
@@ -109,7 +109,7 @@ public class QCustomerRepositoryImpl implements QCustomerRepository {
 		if (!StringUtils.hasText(regionCode)) {
 			return null;
 		}
-		return customer.legalDistrictCode.eq(regionCode);
+		return customer.legalDistrictCode.startsWith(regionCode);
 	}
 
 	private BooleanExpression customerType(Boolean isTenant, Boolean isLandlord,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #380 
## 📝작업 내용
> 고객 필터링 시 주소 필터링 -> LIKE 검색으로 변경